### PR TITLE
ENH: Add CXI devices

### DIFF
--- a/db.json
+++ b/db.json
@@ -11,7 +11,7 @@
         "kwargs": {
             "name": "{{name}}"
         },
-        "last_edit": "Tue Feb 27 10:41:25 2018",
+        "last_edit": "Thu Apr 12 14:40:08 2018",
         "macros": null,
         "name": "cxi_dg1_slits",
         "parent": null,
@@ -20,7 +20,7 @@
         "stand": "DG1",
         "system": "beam control",
         "type": "Slits",
-        "z": -1.0
+        "z": 1035.5
     },
     "CXI:DG1:PIM": {
         "_id": "CXI:DG1:PIM",
@@ -36,7 +36,7 @@
             "name": "{{name}}",
             "prefix_det": "{{prefix_det}}"
         },
-        "last_edit": "Tue Feb 27 16:20:51 2018",
+        "last_edit": "Thu Apr 12 14:39:09 2018",
         "macros": null,
         "name": "cxi_dg1_pim",
         "parent": null,
@@ -46,7 +46,589 @@
         "stand": "DG1",
         "system": "diagnostic",
         "type": "PIM",
-        "z": -1.0
+        "z": 1035.8
+    },
+    "CXI:DG1:RLM:MIRROR": {
+        "_id": "CXI:DG1:RLM:MIRROR",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Thu Apr 12 16:06:42 2018",
+        "device_class": "pcdsdevices.inout.InOutRecordPositioner",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Apr 12 16:06:42 2018",
+        "macros": null,
+        "name": "cxi_reflaser",
+        "parent": null,
+        "prefix": "CXI:DG1:RLM:MIRROR",
+        "screen": null,
+        "stand": "DG1",
+        "system": null,
+        "type": "Device",
+        "z": 1035.2
+    },
+    "CXI:DG1:VGC:01": {
+        "_id": "CXI:DG1:VGC:01",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Thu Apr 12 16:35:56 2018",
+        "device_class": "pcdsdevices.device_types.GateValve",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Apr 12 16:35:56 2018",
+        "macros": null,
+        "name": "cxi_dg1_vgc_01",
+        "parent": null,
+        "prefix": "CXI:DG1:VGC:01",
+        "screen": null,
+        "stand": "DG1",
+        "system": "vacuum",
+        "type": "GateValve",
+        "z": 1035.0
+    },
+    "CXI:DG1:VGC:02": {
+        "_id": "CXI:DG1:VGC:02",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Thu Apr 12 16:36:24 2018",
+        "device_class": "pcdsdevices.device_types.GateValve",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Apr 12 16:36:24 2018",
+        "macros": null,
+        "name": "cxi_dg1_vgc_02",
+        "parent": null,
+        "prefix": "CXI:DG1:VGC:02",
+        "screen": null,
+        "stand": "DG1",
+        "system": "vacuum",
+        "type": "GateValve",
+        "z": 1036.1
+    },
+    "CXI:DG2:IPM": {
+        "_id": "CXI:DG2:IPM",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Wed Apr 18 15:20:42 2018",
+        "data": null,
+        "device_class": "pcdsdevices.device_types.IPM",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Wed Apr 18 15:20:42 2018",
+        "macros": null,
+        "name": "cxi_dg2_ipm",
+        "parent": null,
+        "prefix": "CXI:DG2:IPM",
+        "screen": null,
+        "stand": "DG2",
+        "system": "diagnostic",
+        "type": "IPM",
+        "z": 1043.75
+    },
+    "CXI:DG2:JAWS": {
+        "_id": "CXI:DG2:JAWS",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Tue Feb 27 10:41:25 2018",
+        "device_class": "pcdsdevices.device_types.Slits",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Apr 12 14:55:27 2018",
+        "macros": null,
+        "name": "cxi_dg2_jaws",
+        "parent": null,
+        "prefix": "CXI:DG2:JAWS",
+        "screen": null,
+        "stand": "DG2",
+        "system": "beam control",
+        "type": "Slits",
+        "z": 1043.45
+    },
+    "CXI:DG2:PIM": {
+        "_id": "CXI:DG2:PIM",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Tue Feb 27 12:56:05 2018",
+        "data": null,
+        "device_class": "pcdsdevices.device_types.PIM",
+        "kwargs": {
+            "name": "{{name}}",
+            "prefix_det": "{{prefix_det}}"
+        },
+        "last_edit": "Thu Apr 12 14:42:59 2018",
+        "macros": null,
+        "name": "cxi_dg2_pim",
+        "parent": null,
+        "prefix": "CXI:DG2:PIM",
+        "prefix_det": "CXI:DG2:P6740",
+        "screen": null,
+        "stand": "DG2",
+        "system": "diagnostic",
+        "type": "PIM",
+        "z": 1043.98
+    },
+    "CXI:DG2:VGC:01": {
+        "_id": "CXI:DG2:VGC:01",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Thu Apr 12 16:40:35 2018",
+        "device_class": "pcdsdevices.device_types.GateValve",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Apr 12 16:40:35 2018",
+        "macros": null,
+        "name": "cxi_dg2_vgc_01",
+        "parent": null,
+        "prefix": "CXI:DG2:VGC:01",
+        "screen": null,
+        "stand": "DG2",
+        "system": "vacuum",
+        "type": "GateValve",
+        "z": 1042.9
+    },
+    "CXI:DG2:VGC:02": {
+        "_id": "CXI:DG2:VGC:02",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Thu Apr 12 16:41:09 2018",
+        "device_class": "pcdsdevices.device_types.GateValve",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Apr 12 16:41:09 2018",
+        "macros": null,
+        "name": "cxi_dg2_vgc_02",
+        "parent": null,
+        "prefix": "CXI:DG2:VGC:02",
+        "screen": null,
+        "stand": "DG2",
+        "system": "vacuum",
+        "type": "GateValve",
+        "z": 1044.1
+    },
+    "CXI:DG2:XFLS": {
+        "_id": "CXI:DG2:XFLS",
+        "active": false,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Wed Apr 18 15:31:24 2018",
+        "device_class": "pcdsdevices.device_types.XFLS",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Wed Apr 18 15:40:55 2018",
+        "macros": null,
+        "name": "cxi_dg2_xfls",
+        "parent": null,
+        "prefix": "CXI:DG2:XFLS",
+        "screen": null,
+        "stand": "DG2",
+        "system": null,
+        "type": "Device",
+        "z": 1043.15
+    },
+    "CXI:DG3:IPM": {
+        "_id": "CXI:DG3:IPM",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Wed Apr 18 15:21:52 2018",
+        "data": null,
+        "device_class": "pcdsdevices.device_types.IPM",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Wed Apr 18 15:21:52 2018",
+        "macros": null,
+        "name": "cxi_dg3_ipm",
+        "parent": null,
+        "prefix": "CXI:DG3:IPM",
+        "screen": null,
+        "stand": "DG3",
+        "system": "diagnostic",
+        "type": "IPM",
+        "z": 1057.12
+    },
+    "CXI:DG3:PIM": {
+        "_id": "CXI:DG3:PIM",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Thu Apr 12 16:32:55 2018",
+        "device_class": "pcdsdevices.pim.PIMMotor",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Apr 12 16:32:55 2018",
+        "macros": null,
+        "name": "cxi_dg3_pim",
+        "parent": null,
+        "prefix": "CXI:DG3:PIM",
+        "screen": null,
+        "stand": "DG3",
+        "system": null,
+        "type": "Device",
+        "z": 1057.12
+    },
+    "CXI:DS1:ATT:INOUT": {
+        "_id": "CXI:DS1:ATT:INOUT",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Thu Apr 12 17:13:38 2018",
+        "device_class": "pcdsdevices.inout.InOutRecordPositioner",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Apr 12 17:13:38 2018",
+        "macros": null,
+        "name": "cxi_ds1_att",
+        "parent": null,
+        "prefix": "CXI:DS1:ATT:INOUT",
+        "screen": null,
+        "stand": "DS1",
+        "system": null,
+        "type": "Device",
+        "z": 1048.19
+    },
+    "CXI:DS1:MMS:14": {
+        "_id": "CXI:DS1:MMS:14",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Thu Apr 12 15:22:09 2018",
+        "device_class": "pcdsdevices.device_types.PulsePicker",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Apr 12 15:22:09 2018",
+        "macros": null,
+        "name": "cxi_ds1_pulsepicker",
+        "parent": null,
+        "prefix": "CXI:DS1:MMS:14",
+        "screen": null,
+        "stand": "DS1",
+        "system": "beam control",
+        "type": "PulsePicker",
+        "z": 1047.86
+    },
+    "CXI:DS1:XFLS": {
+        "_id": "CXI:DS1:XFLS",
+        "active": false,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Wed Apr 18 15:33:06 2018",
+        "device_class": "pcdsdevices.device_types.XFLS",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Wed Apr 18 15:40:36 2018",
+        "macros": null,
+        "name": "cxi_ds1_xfls",
+        "parent": null,
+        "prefix": "CXI:DS1:XFLS",
+        "screen": null,
+        "stand": "DS1",
+        "system": null,
+        "type": "Device",
+        "z": 1048.38
+    },
+    "CXI:DSB:ATT": {
+        "_id": "CXI:DSB:ATT",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Thu Apr 12 16:30:09 2018",
+        "device_class": "pcdsdevices.device_types.Attenuator",
+        "kwargs": {
+            "n_filters": "{{n_filters}}",
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Apr 12 16:30:09 2018",
+        "macros": null,
+        "n_filters": 6,
+        "name": "cxi_dsb_attenuators",
+        "parent": null,
+        "prefix": "CXI:DSB:ATT",
+        "screen": null,
+        "stand": "DSB",
+        "system": "beam control",
+        "type": "Attenuator",
+        "z": 1045.21
+    },
+    "CXI:DSB:JAWS": {
+        "_id": "CXI:DSB:JAWS",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Tue Feb 27 10:41:25 2018",
+        "device_class": "pcdsdevices.device_types.Slits",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Apr 12 14:57:01 2018",
+        "macros": null,
+        "name": "cxi_dsb_jaws",
+        "parent": null,
+        "prefix": "CXI:DSB:JAWS",
+        "screen": null,
+        "stand": "DG2",
+        "system": "beam control",
+        "type": "Slits",
+        "z": 1045.71
+    },
+    "CXI:DSC:VGC:01": {
+        "_id": "CXI:DSC:VGC:01",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Mon Apr 16 11:34:36 2018",
+        "device_class": "pcdsdevices.device_types.GateValve",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Mon Apr 16 11:36:29 2018",
+        "macros": null,
+        "name": "cxi_dsc_vgc_01",
+        "parent": null,
+        "prefix": "CXI:DSC:VGC:01",
+        "screen": null,
+        "stand": "DSC",
+        "system": "vacuum",
+        "type": "GateValve",
+        "z": 1050.88
+    },
+    "CXI:KB1:JAWS:DS": {
+        "_id": "CXI:KB1:JAWS:DS",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Tue Feb 27 10:41:25 2018",
+        "device_class": "pcdsdevices.device_types.Slits",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Apr 12 14:49:28 2018",
+        "macros": null,
+        "name": "cxi_kb1_jaws_ds",
+        "parent": null,
+        "prefix": "CXI:KB1:JAWS:DS",
+        "screen": null,
+        "stand": "KB1",
+        "system": "beam control",
+        "type": "Slits",
+        "z": 1039.03
+    },
+    "CXI:KB1:JAWS:US": {
+        "_id": "CXI:KB1:JAWS:US",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Tue Feb 27 10:41:25 2018",
+        "device_class": "pcdsdevices.device_types.Slits",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Apr 12 14:48:00 2018",
+        "macros": null,
+        "name": "cxi_kb1_slits_us",
+        "parent": null,
+        "prefix": "CXI:KB1:JAWS:US",
+        "screen": null,
+        "stand": "KB1",
+        "system": "beam control",
+        "type": "Slits",
+        "z": 1036.85
+    },
+    "CXI:KB1:VGC:01": {
+        "_id": "CXI:KB1:VGC:01",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Thu Apr 12 16:37:08 2018",
+        "device_class": "pcdsdevices.device_types.GateValve",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Apr 12 16:38:12 2018",
+        "macros": null,
+        "name": "cxi_kb1_vgc_01",
+        "parent": null,
+        "prefix": "CXI:KB1:VGC:01",
+        "screen": null,
+        "stand": "KB1",
+        "system": "vacuum",
+        "type": "GateValve",
+        "z": 1037.15
+    },
+    "CXI:KB1:VGC:02": {
+        "_id": "CXI:KB1:VGC:02",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Thu Apr 12 16:37:34 2018",
+        "device_class": "pcdsdevices.device_types.GateValve",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Apr 12 16:37:34 2018",
+        "macros": null,
+        "name": "cxi_kb1_vgc_02",
+        "parent": null,
+        "prefix": "CXI:KB1:VGC:02",
+        "screen": null,
+        "stand": "KB1",
+        "system": "vacuum",
+        "type": "GateValve",
+        "z": 1038.7
+    },
+    "CXI:KB2:VGC:01": {
+        "_id": "CXI:KB2:VGC:01",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Thu Apr 12 16:38:57 2018",
+        "device_class": "pcdsdevices.device_types.GateValve",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Apr 12 16:38:57 2018",
+        "macros": null,
+        "name": "cxi_kb2_vgc_01",
+        "parent": null,
+        "prefix": "CXI:KB2:VGC:01",
+        "screen": null,
+        "stand": "KB2",
+        "system": "vacuum",
+        "type": "GateValve",
+        "z": 1039.27
+    },
+    "CXI:SC1:VGC:01": {
+        "_id": "CXI:SC1:VGC:01",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Mon Apr 16 11:38:59 2018",
+        "device_class": "pcdsdevices.device_types.GateValve",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Mon Apr 16 11:38:59 2018",
+        "macros": null,
+        "name": "cxi_sc1_vgc_01",
+        "parent": null,
+        "prefix": "CXI:SC1:VGC:01",
+        "screen": null,
+        "stand": "SC1",
+        "system": "vacuum",
+        "type": "GateValve",
+        "z": 1046.07
+    },
+    "CXI:SC1:VGC:02": {
+        "_id": "CXI:SC1:VGC:02",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Mon Apr 16 11:38:25 2018",
+        "device_class": "pcdsdevices.device_types.GateValve",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Mon Apr 16 11:38:25 2018",
+        "macros": null,
+        "name": "cxi_sc1_vgc_02",
+        "parent": null,
+        "prefix": "CXI:SC1:VGC:02",
+        "screen": null,
+        "stand": "SC1",
+        "system": "vacuum",
+        "type": "GateValve",
+        "z": 1047.32
+    },
+    "CXI:SC3:VGC:01": {
+        "_id": "CXI:SC3:VGC:01",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Mon Apr 16 11:35:24 2018",
+        "device_class": "pcdsdevices.device_types.GateValve",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Mon Apr 16 11:35:24 2018",
+        "macros": null,
+        "name": "cxi_sc3_vgc_01",
+        "parent": null,
+        "prefix": "CXI:SC3:VGC:01",
+        "screen": null,
+        "stand": "SC3",
+        "system": "vacuum",
+        "type": "GateValve",
+        "z": 1048.78
     },
     "FEE1:M1H": {
         "_id": "FEE1:M1H",
@@ -243,7 +825,7 @@
     },
     "HFX:DG3:IPM": {
         "_id": "HFX:DG3:IPM",
-        "active": true,
+        "active": false,
         "args": [
             "{{prefix}}"
         ],
@@ -254,7 +836,7 @@
         "kwargs": {
             "name": "{{name}}"
         },
-        "last_edit": "Tue Feb 27 11:40:14 2018",
+        "last_edit": "Wed Apr 18 15:28:14 2018",
         "macros": null,
         "name": "xrt_dg3m_ipm",
         "parent": null,


### PR DESCRIPTION
* Add all devices we support in the `CXI` beamline
* HFX DG3 IPM does not appear to exist. It was set to inactive.
* The XFLS in CXI were set to inactive until the IOCs are updated to be compatible with the `XFLS` class in `pcdsdevices`.