### PR TITLE
Update README.md with current backup details

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,6 @@ client = happi.Client(path='path/to/device_config/db.json')
 ```
 
 ## Backup
-A daily backup is done via CRON job and kept on the branch `backup`. This is
-here in case an error is made and the local copy of the `device_config` is
-lost.
+A daily backup is done via CRON job which commits any changes to the `deploy` branch and
+pushes to https://github.com/pcdshub/device_config/. This is performed in case an error
+is made and the local copy of the `device_config` is lost.


### PR DESCRIPTION
Fixes #6.

I created a simple cronjob that commits and pushes changes like we used to:
```
0 17 * * * (cd /reg/g/pcds/pyps/apps/hutch-python/device_config && git commit -am "Automatic Backup @ `date`" && git push origin-ssh deploy)
```

This is currently run on psbuild-rhel7 but should be moved to pscron when it comes online.
Tested at 5 o'clock today.