### PR TITLE
MNT: Change device IDs from prefixes to names

### DIFF
--- a/db.json
+++ b/db.json
@@ -1,3899 +1,4 @@
 {
-    "CXI:DG1:JAWS": {
-        "_id": "CXI:DG1:JAWS",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "CXI",
-        "creation": "Tue Feb 27 10:41:25 2018",
-        "device_class": "pcdsdevices.device_types.Slits",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Thu Apr 12 14:40:08 2018",
-        "macros": null,
-        "name": "cxi_dg1_slits",
-        "parent": null,
-        "prefix": "CXI:DG1:JAWS",
-        "screen": null,
-        "stand": "DG1",
-        "system": "beam control",
-        "type": "pcdsdevices.happi.containers.Slits",
-        "z": 1035.5
-    },
-    "CXI:DG1:PIM": {
-        "_id": "CXI:DG1:PIM",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "CXI",
-        "creation": "Tue Feb 27 12:56:05 2018",
-        "data": null,
-        "device_class": "pcdsdevices.pim.PIM",
-        "kwargs": {
-            "name": "{{name}}",
-            "prefix_det": "{{prefix_det}}"
-        },
-        "last_edit": "Thu Apr 12 14:39:09 2018",
-        "macros": null,
-        "name": "cxi_dg1_pim",
-        "parent": null,
-        "prefix": "CXI:DG1:PIM",
-        "prefix_det": "CXI:DG1:P6740",
-        "screen": null,
-        "stand": "DG1",
-        "system": "diagnostic",
-        "type": "pcdsdevices.happi.containers.PIM",
-        "z": 1035.8
-    },
-    "CXI:DG1:RLM:MIRROR": {
-        "_id": "CXI:DG1:RLM:MIRROR",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "CXI",
-        "creation": "Thu Apr 12 16:06:42 2018",
-        "device_class": "pcdsdevices.inout.InOutRecordPositioner",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Thu Apr 12 16:06:42 2018",
-        "macros": null,
-        "name": "cxi_reflaser",
-        "parent": null,
-        "prefix": "CXI:DG1:RLM:MIRROR",
-        "screen": null,
-        "stand": "DG1",
-        "system": null,
-        "type": "pcdsdevices.happi.containers.LCLSItem",
-        "z": 1035.2
-    },
-    "CXI:DG1:VGC:01": {
-        "_id": "CXI:DG1:VGC:01",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "CXI",
-        "creation": "Thu Apr 12 16:35:56 2018",
-        "device_class": "pcdsdevices.device_types.GateValve",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Thu Apr 12 16:35:56 2018",
-        "macros": null,
-        "name": "cxi_dg1_vgc_01",
-        "parent": null,
-        "prefix": "CXI:DG1:VGC:01",
-        "screen": null,
-        "stand": "DG1",
-        "system": "vacuum",
-        "type": "pcdsdevices.happi.containers.GateValve",
-        "z": 1035.0
-    },
-    "CXI:DG1:VGC:02": {
-        "_id": "CXI:DG1:VGC:02",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "CXI",
-        "creation": "Thu Apr 12 16:36:24 2018",
-        "device_class": "pcdsdevices.device_types.GateValve",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Thu Apr 12 16:36:24 2018",
-        "macros": null,
-        "name": "cxi_dg1_vgc_02",
-        "parent": null,
-        "prefix": "CXI:DG1:VGC:02",
-        "screen": null,
-        "stand": "DG1",
-        "system": "vacuum",
-        "type": "pcdsdevices.happi.containers.GateValve",
-        "z": 1036.1
-    },
-    "CXI:DG2:IPM": {
-        "_id": "CXI:DG2:IPM",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "CXI",
-        "creation": "Wed Apr 18 15:20:42 2018",
-        "data": null,
-        "device_class": "pcdsdevices.device_types.IPM",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Wed Apr 18 15:20:42 2018",
-        "macros": null,
-        "name": "cxi_dg2_ipm",
-        "parent": null,
-        "prefix": "CXI:DG2:IPM",
-        "screen": null,
-        "stand": "DG2",
-        "system": "diagnostic",
-        "type": "pcdsdevices.happi.containers.IPM",
-        "z": 1043.75
-    },
-    "CXI:DG2:JAWS": {
-        "_id": "CXI:DG2:JAWS",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "CXI",
-        "creation": "Tue Feb 27 10:41:25 2018",
-        "device_class": "pcdsdevices.device_types.Slits",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Thu Apr 12 14:55:27 2018",
-        "macros": null,
-        "name": "cxi_dg2_jaws",
-        "parent": null,
-        "prefix": "CXI:DG2:JAWS",
-        "screen": null,
-        "stand": "DG2",
-        "system": "beam control",
-        "type": "pcdsdevices.happi.containers.Slits",
-        "z": 1043.45
-    },
-    "CXI:DG2:MMS:05": {
-        "_id": "CXI:DG2:MMS:05",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "CXI",
-        "creation": "Tue Aug 21 09:29:22 2018",
-        "device_class": "pcdsdevices.device_types.IMS",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Aug 21 09:29:22 2018",
-        "macros": null,
-        "name": "cxi_dg2_lens_x",
-        "parent": null,
-        "prefix": "CXI:DG2:MMS:05",
-        "screen": null,
-        "stand": "DG2",
-        "system": null,
-        "type": "pcdsdevices.happi.containers.LCLSItem",
-        "z": -1.0
-    },
-    "CXI:DG2:MMS:06": {
-        "_id": "CXI:DG2:MMS:06",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "CXI",
-        "creation": "Tue Aug 21 09:29:45 2018",
-        "device_class": "pcdsdevices.device_types.IMS",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Aug 21 09:29:45 2018",
-        "macros": null,
-        "name": "cxi_dg2_lens_y",
-        "parent": null,
-        "prefix": "CXI:DG2:MMS:06",
-        "screen": null,
-        "stand": "DG2",
-        "system": null,
-        "type": "pcdsdevices.happi.containers.LCLSItem",
-        "z": -1.0
-    },
-    "CXI:DG2:PIM": {
-        "_id": "CXI:DG2:PIM",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "CXI",
-        "creation": "Tue Feb 27 12:56:05 2018",
-        "data": null,
-        "device_class": "pcdsdevices.pim.PIM",
-        "kwargs": {
-            "name": "{{name}}",
-            "prefix_det": "{{prefix_det}}"
-        },
-        "last_edit": "Thu Apr 12 14:42:59 2018",
-        "macros": null,
-        "name": "cxi_dg2_pim",
-        "parent": null,
-        "prefix": "CXI:DG2:PIM",
-        "prefix_det": "CXI:DG2:P6740",
-        "screen": null,
-        "stand": "DG2",
-        "system": "diagnostic",
-        "type": "pcdsdevices.happi.containers.PIM",
-        "z": 1043.98
-    },
-    "CXI:DG2:VGC:01": {
-        "_id": "CXI:DG2:VGC:01",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "CXI",
-        "creation": "Thu Apr 12 16:40:35 2018",
-        "device_class": "pcdsdevices.device_types.GateValve",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Thu Apr 12 16:40:35 2018",
-        "macros": null,
-        "name": "cxi_dg2_vgc_01",
-        "parent": null,
-        "prefix": "CXI:DG2:VGC:01",
-        "screen": null,
-        "stand": "DG2",
-        "system": "vacuum",
-        "type": "pcdsdevices.happi.containers.GateValve",
-        "z": 1042.9
-    },
-    "CXI:DG2:VGC:02": {
-        "_id": "CXI:DG2:VGC:02",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "CXI",
-        "creation": "Thu Apr 12 16:41:09 2018",
-        "device_class": "pcdsdevices.device_types.GateValve",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Thu Apr 12 16:41:09 2018",
-        "macros": null,
-        "name": "cxi_dg2_vgc_02",
-        "parent": null,
-        "prefix": "CXI:DG2:VGC:02",
-        "screen": null,
-        "stand": "DG2",
-        "system": "vacuum",
-        "type": "pcdsdevices.happi.containers.GateValve",
-        "z": 1044.1
-    },
-    "CXI:DG2:XFLS": {
-        "_id": "CXI:DG2:XFLS",
-        "active": false,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "CXI",
-        "creation": "Wed Apr 18 15:31:24 2018",
-        "device_class": "pcdsdevices.device_types.XFLS",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Wed Apr 18 15:40:55 2018",
-        "macros": null,
-        "name": "cxi_dg2_xfls",
-        "parent": null,
-        "prefix": "CXI:DG2:XFLS",
-        "screen": null,
-        "stand": "DG2",
-        "system": null,
-        "type": "pcdsdevices.happi.containers.LCLSItem",
-        "z": 1043.15
-    },
-    "CXI:DG3:IPM": {
-        "_id": "CXI:DG3:IPM",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "CXI",
-        "creation": "Wed Apr 18 15:21:52 2018",
-        "data": null,
-        "device_class": "pcdsdevices.device_types.IPM",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Wed Apr 18 15:21:52 2018",
-        "macros": null,
-        "name": "cxi_dg3_ipm",
-        "parent": null,
-        "prefix": "CXI:DG3:IPM",
-        "screen": null,
-        "stand": "DG3",
-        "system": "diagnostic",
-        "type": "pcdsdevices.happi.containers.IPM",
-        "z": 1057.12
-    },
-    "CXI:DG3:PIM": {
-        "_id": "CXI:DG3:PIM",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "CXI",
-        "creation": "Thu Apr 12 16:32:55 2018",
-        "device_class": "pcdsdevices.pim.PIMWithFocus",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Thu Apr 12 16:32:55 2018",
-        "macros": null,
-        "name": "cxi_dg3_pim",
-        "parent": null,
-        "prefix": "CXI:DG3:PIM",
-        "screen": null,
-        "stand": "DG3",
-        "system": null,
-        "type": "pcdsdevices.happi.containers.LCLSItem",
-        "z": 1057.12
-    },
-    "CXI:DS1:ATT:INOUT": {
-        "_id": "CXI:DS1:ATT:INOUT",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "CXI",
-        "creation": "Thu Apr 12 17:13:38 2018",
-        "device_class": "pcdsdevices.inout.InOutRecordPositioner",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Thu Apr 12 17:13:38 2018",
-        "macros": null,
-        "name": "cxi_ds1_att",
-        "parent": null,
-        "prefix": "CXI:DS1:ATT:INOUT",
-        "screen": null,
-        "stand": "DS1",
-        "system": null,
-        "type": "pcdsdevices.happi.containers.LCLSItem",
-        "z": 1048.19
-    },
-    "CXI:DS1:MMS:14": {
-        "_id": "CXI:DS1:MMS:14",
-        "active": false,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "CXI",
-        "creation": "Thu Apr 12 15:22:09 2018",
-        "device_class": "pcdsdevices.device_types.PulsePicker",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Thu Sep 13 21:44:25 2018",
-        "macros": null,
-        "name": "cxi_ds1_pulsepicker",
-        "parent": null,
-        "prefix": "CXI:DS1:MMS:14",
-        "screen": null,
-        "stand": "DS1",
-        "system": "beam control",
-        "type": "pcdsdevices.happi.containers.PulsePicker",
-        "z": 1047.86
-    },
-    "CXI:DS1:XFLS": {
-        "_id": "CXI:DS1:XFLS",
-        "active": false,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "CXI",
-        "creation": "Wed Apr 18 15:33:06 2018",
-        "device_class": "pcdsdevices.device_types.XFLS",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Wed Apr 18 15:40:36 2018",
-        "macros": null,
-        "name": "cxi_ds1_xfls",
-        "parent": null,
-        "prefix": "CXI:DS1:XFLS",
-        "screen": null,
-        "stand": "DS1",
-        "system": null,
-        "type": "pcdsdevices.happi.containers.LCLSItem",
-        "z": 1048.38
-    },
-    "CXI:DSB:ATT": {
-        "_id": "CXI:DSB:ATT",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "CXI",
-        "creation": "Thu Apr 12 16:30:09 2018",
-        "detailed_screen": null,
-        "device_class": "pcdsdevices.device_types.Attenuator",
-        "documentation": null,
-        "embedded_screen": null,
-        "engineering_screen": null,
-        "kwargs": {
-            "n_filters": "{{n_filters}}",
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue May  7 16:35:57 2019",
-        "lightpath": false,
-        "macros": null,
-        "n_filters": 6,
-        "name": "cxi_dsb_attenuator",
-        "parent": null,
-        "prefix": "CXI:DSB:ATT",
-        "screen": null,
-        "stand": "DSB",
-        "system": "beam control",
-        "type": "pcdsdevices.happi.containers.Attenuator",
-        "z": 1045.21
-    },
-    "CXI:DSB:JAWS": {
-        "_id": "CXI:DSB:JAWS",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "CXI",
-        "creation": "Tue Feb 27 10:41:25 2018",
-        "device_class": "pcdsdevices.device_types.Slits",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Thu Apr 12 14:57:01 2018",
-        "macros": null,
-        "name": "cxi_dsb_jaws",
-        "parent": null,
-        "prefix": "CXI:DSB:JAWS",
-        "screen": null,
-        "stand": "DG2",
-        "system": "beam control",
-        "type": "pcdsdevices.happi.containers.Slits",
-        "z": 1045.71
-    },
-    "CXI:DSC:VGC:01": {
-        "_id": "CXI:DSC:VGC:01",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "CXI",
-        "creation": "Mon Apr 16 11:34:36 2018",
-        "device_class": "pcdsdevices.device_types.GateValve",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Mon Apr 16 11:36:29 2018",
-        "macros": null,
-        "name": "cxi_dsc_vgc_01",
-        "parent": null,
-        "prefix": "CXI:DSC:VGC:01",
-        "screen": null,
-        "stand": "DSC",
-        "system": "vacuum",
-        "type": "pcdsdevices.happi.containers.GateValve",
-        "z": 1050.88
-    },
-    "CXI:KB1:JAWS:DS": {
-        "_id": "CXI:KB1:JAWS:DS",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "CXI",
-        "creation": "Tue Feb 27 10:41:25 2018",
-        "device_class": "pcdsdevices.device_types.Slits",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Thu Apr 12 14:49:28 2018",
-        "macros": null,
-        "name": "cxi_kb1_jaws_ds",
-        "parent": null,
-        "prefix": "CXI:KB1:JAWS:DS",
-        "screen": null,
-        "stand": "KB1",
-        "system": "beam control",
-        "type": "pcdsdevices.happi.containers.Slits",
-        "z": 1039.03
-    },
-    "CXI:KB1:JAWS:US": {
-        "_id": "CXI:KB1:JAWS:US",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "CXI",
-        "creation": "Tue Feb 27 10:41:25 2018",
-        "device_class": "pcdsdevices.device_types.Slits",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Thu Apr 12 14:48:00 2018",
-        "macros": null,
-        "name": "cxi_kb1_slits_us",
-        "parent": null,
-        "prefix": "CXI:KB1:JAWS:US",
-        "screen": null,
-        "stand": "KB1",
-        "system": "beam control",
-        "type": "pcdsdevices.happi.containers.Slits",
-        "z": 1036.85
-    },
-    "CXI:KB1:MMS:05": {
-        "_id": "CXI:KB1:MMS:05",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "CXI",
-        "creation": "Tue Aug 21 09:15:22 2018",
-        "device_class": "pcdsdevices.device_types.IMS",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Aug 21 09:23:32 2018",
-        "macros": null,
-        "name": "cxi_kb1_hx",
-        "parent": null,
-        "prefix": "CXI:KB1:MMS:05",
-        "screen": null,
-        "stand": "KB1",
-        "system": null,
-        "type": "pcdsdevices.happi.containers.LCLSItem",
-        "z": -1.0
-    },
-    "CXI:KB1:MMS:06": {
-        "_id": "CXI:KB1:MMS:06",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "CXI",
-        "creation": "Tue Aug 21 09:15:39 2018",
-        "device_class": "pcdsdevices.device_types.IMS",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Aug 21 09:23:32 2018",
-        "macros": null,
-        "name": "cxi_kb1_hy",
-        "parent": null,
-        "prefix": "CXI:KB1:MMS:06",
-        "screen": null,
-        "stand": "KB1",
-        "system": null,
-        "type": "pcdsdevices.happi.containers.LCLSItem",
-        "z": -1.0
-    },
-    "CXI:KB1:MMS:07": {
-        "_id": "CXI:KB1:MMS:07",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "CXI",
-        "creation": "Tue Aug 21 09:13:03 2018",
-        "device_class": "pcdsdevices.device_types.IMS",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Aug 21 09:23:32 2018",
-        "macros": null,
-        "name": "cxi_kb1_hp",
-        "parent": null,
-        "prefix": "CXI:KB1:MMS:07",
-        "screen": null,
-        "stand": "KB1",
-        "system": null,
-        "type": "pcdsdevices.happi.containers.LCLSItem",
-        "z": -1.0
-    },
-    "CXI:KB1:MMS:08": {
-        "_id": "CXI:KB1:MMS:08",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "CXI",
-        "creation": "Tue Aug 21 09:14:56 2018",
-        "device_class": "pcdsdevices.device_types.IMS",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Aug 21 09:23:32 2018",
-        "macros": null,
-        "name": "cxi_kb1_hr",
-        "parent": null,
-        "prefix": "CXI:KB1:MMS:08",
-        "screen": null,
-        "stand": "KB1",
-        "system": null,
-        "type": "pcdsdevices.happi.containers.LCLSItem",
-        "z": -1.0
-    },
-    "CXI:KB1:MMS:09": {
-        "_id": "CXI:KB1:MMS:09",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "CXI",
-        "creation": "Tue Aug 21 09:13:54 2018",
-        "device_class": "pcdsdevices.device_types.IMS",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Aug 21 09:23:32 2018",
-        "macros": null,
-        "name": "cxi_kb1_vx",
-        "parent": null,
-        "prefix": "CXI:KB1:MMS:09",
-        "screen": null,
-        "stand": "KB1",
-        "system": null,
-        "type": "pcdsdevices.happi.containers.LCLSItem",
-        "z": -1.0
-    },
-    "CXI:KB1:MMS:10": {
-        "_id": "CXI:KB1:MMS:10",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "CXI",
-        "creation": "Tue Aug 21 09:14:34 2018",
-        "device_class": "pcdsdevices.device_types.IMS",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Aug 21 09:23:32 2018",
-        "macros": null,
-        "name": "cxi_kb1_vy",
-        "parent": null,
-        "prefix": "CXI:KB1:MMS:10",
-        "screen": null,
-        "stand": "KB1",
-        "system": null,
-        "type": "pcdsdevices.happi.containers.LCLSItem",
-        "z": -1.0
-    },
-    "CXI:KB1:MMS:11": {
-        "_id": "CXI:KB1:MMS:11",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "CXI",
-        "creation": "Tue Aug 21 09:13:37 2018",
-        "device_class": "pcdsdevices.device_types.IMS",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Aug 21 09:23:32 2018",
-        "macros": null,
-        "name": "cxi_kb1_vp",
-        "parent": null,
-        "prefix": "CXI:KB1:MMS:11",
-        "screen": null,
-        "stand": "KB1",
-        "system": null,
-        "type": "pcdsdevices.happi.containers.LCLSItem",
-        "z": -1.0
-    },
-    "CXI:KB1:VGC:01": {
-        "_id": "CXI:KB1:VGC:01",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "CXI",
-        "creation": "Thu Apr 12 16:37:08 2018",
-        "device_class": "pcdsdevices.device_types.GateValve",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Thu Apr 12 16:38:12 2018",
-        "macros": null,
-        "name": "cxi_kb1_vgc_01",
-        "parent": null,
-        "prefix": "CXI:KB1:VGC:01",
-        "screen": null,
-        "stand": "KB1",
-        "system": "vacuum",
-        "type": "pcdsdevices.happi.containers.GateValve",
-        "z": 1037.15
-    },
-    "CXI:KB1:VGC:02": {
-        "_id": "CXI:KB1:VGC:02",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "CXI",
-        "creation": "Thu Apr 12 16:37:34 2018",
-        "device_class": "pcdsdevices.device_types.GateValve",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Thu Apr 12 16:37:34 2018",
-        "macros": null,
-        "name": "cxi_kb1_vgc_02",
-        "parent": null,
-        "prefix": "CXI:KB1:VGC:02",
-        "screen": null,
-        "stand": "KB1",
-        "system": "vacuum",
-        "type": "pcdsdevices.happi.containers.GateValve",
-        "z": 1038.7
-    },
-    "CXI:KB2:MMS:01": {
-        "_id": "CXI:KB2:MMS:01",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "CXI",
-        "creation": "Tue Aug 21 09:20:23 2018",
-        "device_class": "pcdsdevices.device_types.IMS",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Aug 21 09:23:32 2018",
-        "macros": null,
-        "name": "cxi_kb2_hx",
-        "parent": null,
-        "prefix": "CXI:KB2:MMS:01",
-        "screen": null,
-        "stand": "KB2",
-        "system": null,
-        "type": "pcdsdevices.happi.containers.LCLSItem",
-        "z": -1.0
-    },
-    "CXI:KB2:MMS:02": {
-        "_id": "CXI:KB2:MMS:02",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "CXI",
-        "creation": "Tue Aug 21 09:20:39 2018",
-        "device_class": "pcdsdevices.device_types.IMS",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Aug 21 09:23:32 2018",
-        "macros": null,
-        "name": "cxi_kb2_hy",
-        "parent": null,
-        "prefix": "CXI:KB2:MMS:02",
-        "screen": null,
-        "stand": "KB2",
-        "system": null,
-        "type": "pcdsdevices.happi.containers.LCLSItem",
-        "z": -1.0
-    },
-    "CXI:KB2:MMS:03": {
-        "_id": "CXI:KB2:MMS:03",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "CXI",
-        "creation": "Tue Aug 21 09:22:12 2018",
-        "device_class": "pcdsdevices.device_types.IMS",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Aug 21 09:23:32 2018",
-        "macros": null,
-        "name": "cxi_kb2_hl",
-        "parent": null,
-        "prefix": "CXI:KB2:MMS:03",
-        "screen": null,
-        "stand": "KB2",
-        "system": null,
-        "type": "pcdsdevices.happi.containers.LCLSItem",
-        "z": -1.0
-    },
-    "CXI:KB2:MMS:04": {
-        "_id": "CXI:KB2:MMS:04",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "CXI",
-        "creation": "Tue Aug 21 09:17:51 2018",
-        "device_class": "pcdsdevices.device_types.IMS",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Aug 21 09:23:32 2018",
-        "macros": null,
-        "name": "cxi_kb2_hp",
-        "parent": null,
-        "prefix": "CXI:KB2:MMS:04",
-        "screen": null,
-        "stand": "KB2",
-        "system": null,
-        "type": "pcdsdevices.happi.containers.LCLSItem",
-        "z": -1.0
-    },
-    "CXI:KB2:MMS:05": {
-        "_id": "CXI:KB2:MMS:05",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "CXI",
-        "creation": "Tue Aug 21 09:18:35 2018",
-        "device_class": "pcdsdevices.device_types.IMS",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Aug 21 09:23:32 2018",
-        "macros": null,
-        "name": "cxi_kb2_hr",
-        "parent": null,
-        "prefix": "CXI:KB2:MMS:05",
-        "screen": null,
-        "stand": "KB2",
-        "system": null,
-        "type": "pcdsdevices.happi.containers.LCLSItem",
-        "z": -1.0
-    },
-    "CXI:KB2:MMS:06": {
-        "_id": "CXI:KB2:MMS:06",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "CXI",
-        "creation": "Tue Aug 21 09:21:17 2018",
-        "device_class": "pcdsdevices.device_types.IMS",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Aug 21 09:23:32 2018",
-        "macros": null,
-        "name": "cxi_kb2_vx",
-        "parent": null,
-        "prefix": "CXI:KB2:MMS:06",
-        "screen": null,
-        "stand": "KB2",
-        "system": null,
-        "type": "pcdsdevices.happi.containers.LCLSItem",
-        "z": -1.0
-    },
-    "CXI:KB2:MMS:07": {
-        "_id": "CXI:KB2:MMS:07",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "CXI",
-        "creation": "Tue Aug 21 09:21:22 2018",
-        "device_class": "pcdsdevices.device_types.IMS",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Aug 21 09:23:32 2018",
-        "macros": null,
-        "name": "cxi_kb2_vy",
-        "parent": null,
-        "prefix": "CXI:KB2:MMS:07",
-        "screen": null,
-        "stand": "KB2",
-        "system": null,
-        "type": "pcdsdevices.happi.containers.LCLSItem",
-        "z": -1.0
-    },
-    "CXI:KB2:MMS:08": {
-        "_id": "CXI:KB2:MMS:08",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "CXI",
-        "creation": "Tue Aug 21 09:18:12 2018",
-        "device_class": "pcdsdevices.device_types.IMS",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Aug 21 09:23:32 2018",
-        "macros": null,
-        "name": "cxi_kb2_vp",
-        "parent": null,
-        "prefix": "CXI:KB2:MMS:08",
-        "screen": null,
-        "stand": "KB2",
-        "system": null,
-        "type": "pcdsdevices.happi.containers.LCLSItem",
-        "z": -1.0
-    },
-    "CXI:KB2:VGC:01": {
-        "_id": "CXI:KB2:VGC:01",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "CXI",
-        "creation": "Thu Apr 12 16:38:57 2018",
-        "device_class": "pcdsdevices.device_types.GateValve",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Thu Apr 12 16:38:57 2018",
-        "macros": null,
-        "name": "cxi_kb2_vgc_01",
-        "parent": null,
-        "prefix": "CXI:KB2:VGC:01",
-        "screen": null,
-        "stand": "KB2",
-        "system": "vacuum",
-        "type": "pcdsdevices.happi.containers.GateValve",
-        "z": 1039.27
-    },
-    "CXI:SC1:VGC:01": {
-        "_id": "CXI:SC1:VGC:01",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "CXI",
-        "creation": "Mon Apr 16 11:38:59 2018",
-        "device_class": "pcdsdevices.device_types.GateValve",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Mon Apr 16 11:38:59 2018",
-        "macros": null,
-        "name": "cxi_sc1_vgc_01",
-        "parent": null,
-        "prefix": "CXI:SC1:VGC:01",
-        "screen": null,
-        "stand": "SC1",
-        "system": "vacuum",
-        "type": "pcdsdevices.happi.containers.GateValve",
-        "z": 1046.07
-    },
-    "CXI:SC1:VGC:02": {
-        "_id": "CXI:SC1:VGC:02",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "CXI",
-        "creation": "Mon Apr 16 11:38:25 2018",
-        "device_class": "pcdsdevices.device_types.GateValve",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Mon Apr 16 11:38:25 2018",
-        "macros": null,
-        "name": "cxi_sc1_vgc_02",
-        "parent": null,
-        "prefix": "CXI:SC1:VGC:02",
-        "screen": null,
-        "stand": "SC1",
-        "system": "vacuum",
-        "type": "pcdsdevices.happi.containers.GateValve",
-        "z": 1047.32
-    },
-    "CXI:SC3:VGC:01": {
-        "_id": "CXI:SC3:VGC:01",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "CXI",
-        "creation": "Mon Apr 16 11:35:24 2018",
-        "device_class": "pcdsdevices.device_types.GateValve",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Mon Apr 16 11:35:24 2018",
-        "macros": null,
-        "name": "cxi_sc3_vgc_01",
-        "parent": null,
-        "prefix": "CXI:SC3:VGC:01",
-        "screen": null,
-        "stand": "SC3",
-        "system": "vacuum",
-        "type": "pcdsdevices.happi.containers.GateValve",
-        "z": 1048.78
-    },
-    "FEE1:M1H": {
-        "_id": "FEE1:M1H",
-        "active": false,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "HXD",
-        "creation": "Tue Feb 27 15:50:33 2018",
-        "device_class": "pcdsdevices.device_types.OffsetMirror",
-        "kwargs": {
-            "name": "{{name}}",
-            "prefix_xy": "{{prefix_xy}}",
-            "xgantry_prefix": "{{xgantry_prefix}}"
-        },
-        "last_edit": "Tue Feb 27 15:50:33 2018",
-        "macros": null,
-        "name": "fee_m1h",
-        "parent": null,
-        "prefix": "FEE1:M1H",
-        "prefix_xy": "STEP:M1H",
-        "screen": null,
-        "stand": null,
-        "system": "beam control",
-        "type": "pcdsdevices.happi.containers.OffsetMirror",
-        "xgantry_prefix": "STEP:FEE1:611:MOTR",
-        "z": 740.51
-    },
-    "FEE1:M2H": {
-        "_id": "FEE1:M2H",
-        "active": false,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "HXD",
-        "creation": "Tue Feb 27 16:00:54 2018",
-        "device_class": "pcdsdevices.device_types.OffsetMirror",
-        "kwargs": {
-            "name": "{{name}}",
-            "prefix_xy": "{{prefix_xy}}",
-            "xgantry_prefix": "{{xgantry_prefix}}"
-        },
-        "last_edit": "Tue Feb 27 16:00:54 2018",
-        "macros": null,
-        "name": "fee_m2h",
-        "parent": null,
-        "prefix": "FEE1:M2H",
-        "prefix_xy": "STEP:M2H",
-        "screen": null,
-        "stand": null,
-        "system": "beam control",
-        "type": "pcdsdevices.happi.containers.OffsetMirror",
-        "xgantry_prefix": "STEP:FEE1:861:MOTR",
-        "z": 751.8430000000001
-    },
-    "HFA:SND:VGC:01": {
-        "_id": "HFA:SND:VGC:01",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "CXI",
-        "creation": "Thu Feb 15 17:52:07 2018",
-        "device_class": "pcdsdevices.device_types.GateValve",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Thu Feb 15 18:25:23 2018",
-        "macros": null,
-        "name": "cxi_snd_valve",
-        "parent": null,
-        "prefix": "HFA:SND:VGC:01",
-        "screen": null,
-        "stand": null,
-        "system": "vacuum",
-        "type": "pcdsdevices.happi.containers.GateValve",
-        "z": 996.61
-    },
-    "HFX:DG2:IPM": {
-        "_id": "HFX:DG2:IPM",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "HXD",
-        "creation": "Tue Feb 27 11:40:14 2018",
-        "data": null,
-        "device_class": "pcdsdevices.device_types.IPM",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Feb 27 11:40:14 2018",
-        "lightpath": true,
-        "macros": null,
-        "name": "hxd_dg2_ipm",
-        "parent": null,
-        "prefix": "HFX:DG2:IPM",
-        "screen": null,
-        "stand": null,
-        "system": "diagnostic",
-        "type": "pcdsdevices.happi.containers.IPM",
-        "z": 958.8560000000001
-    },
-    "HFX:DG2:JAWS": {
-        "_id": "HFX:DG2:JAWS",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "HXD",
-        "creation": "Tue Feb 27 10:41:25 2018",
-        "device_class": "pcdsdevices.device_types.Slits",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Feb 27 10:41:25 2018",
-        "lightpath": true,
-        "macros": null,
-        "name": "hxd_dg2_slits",
-        "parent": null,
-        "prefix": "HFX:DG2:JAWS",
-        "screen": null,
-        "stand": null,
-        "system": "beam control",
-        "type": "pcdsdevices.happi.containers.Slits",
-        "z": 958.689
-    },
-    "HFX:DG2:PIM": {
-        "_id": "HFX:DG2:PIM",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "HXD",
-        "creation": "Tue Feb 27 11:15:18 2018",
-        "device_class": "pcdsdevices.pim.PIM",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Feb 27 11:15:18 2018",
-        "lightpath": true,
-        "macros": null,
-        "name": "hxd_dg2_pim",
-        "parent": null,
-        "prefix": "HFX:DG2:PIM",
-        "screen": null,
-        "stand": null,
-        "system": null,
-        "type": "pcdsdevices.happi.containers.LCLSItem",
-        "z": 959.053
-    },
-    "HFX:DG2:STP:01": {
-        "_id": "HFX:DG2:STP:01",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "HXD",
-        "creation": "Tue Feb 27 11:46:45 2018",
-        "device_class": "pcdsdevices.device_types.Stopper",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Feb 27 15:04:38 2018",
-        "lightpath": true,
-        "macros": null,
-        "name": "hxd_dg2_stopper",
-        "parent": null,
-        "prefix": "HFX:DG2:STP:01",
-        "screen": null,
-        "stand": null,
-        "system": null,
-        "type": "pcdsdevices.happi.containers.Stopper",
-        "z": 959.2
-    },
-    "HFX:DG2:VGC:01": {
-        "_id": "HFX:DG2:VGC:01",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "HXD",
-        "creation": "Thu Feb 15 17:52:07 2018",
-        "device_class": "pcdsdevices.device_types.GateValve",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Thu Feb 15 18:25:23 2018",
-        "lightpath": true,
-        "macros": null,
-        "name": "hxd_dg2_valve",
-        "parent": null,
-        "prefix": "HFX:DG2:VGC:01",
-        "screen": null,
-        "stand": null,
-        "system": "vacuum",
-        "type": "pcdsdevices.happi.containers.GateValve",
-        "z": 959.441
-    },
-    "HFX:DG3:IPM": {
-        "_id": "HFX:DG3:IPM",
-        "active": false,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "HXD",
-        "creation": "Tue Feb 27 11:40:14 2018",
-        "data": null,
-        "device_class": "pcdsdevices.device_types.IPM",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Wed Apr 18 15:28:14 2018",
-        "macros": null,
-        "name": "xrt_dg3m_ipm",
-        "parent": null,
-        "prefix": "HFX:DG3:IPM",
-        "screen": null,
-        "stand": null,
-        "system": "diagnostic",
-        "type": "pcdsdevices.happi.containers.IPM",
-        "z": 978.9
-    },
-    "HFX:DG3:JAWS": {
-        "_id": "HFX:DG3:JAWS",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "HXD",
-        "creation": "Tue Feb 27 10:41:25 2018",
-        "device_class": "pcdsdevices.device_types.Slits",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Feb 27 10:41:25 2018",
-        "macros": null,
-        "name": "xrt_dg3m_slits",
-        "parent": null,
-        "prefix": "HFX:DG3:JAWS",
-        "screen": null,
-        "stand": null,
-        "system": "beam control",
-        "type": "pcdsdevices.happi.containers.Slits",
-        "z": 978.813
-    },
-    "HFX:DG3:PIM": {
-        "_id": "HFX:DG3:PIM",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "HXD",
-        "creation": "Tue Feb 27 12:56:05 2018",
-        "data": null,
-        "device_class": "pcdsdevices.pim.PIM",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Feb 27 16:16:11 2018",
-        "macros": null,
-        "name": "xrt_dg3m_pim",
-        "parent": null,
-        "prefix": "HFX:DG3:PIM",
-        "prefix_det": null,
-        "screen": null,
-        "stand": null,
-        "system": "diagnostic",
-        "type": "pcdsdevices.happi.containers.PIM",
-        "z": 978.913
-    },
-    "HFX:DIA:VGC:01": {
-        "_id": "HFX:DIA:VGC:01",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "CXI",
-        "creation": "Thu Feb 15 17:52:07 2018",
-        "device_class": "pcdsdevices.device_types.GateValve",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Thu Feb 15 18:25:23 2018",
-        "macros": null,
-        "name": "cxi_dia_valve",
-        "parent": null,
-        "prefix": "HFX:DIA:VGC:01",
-        "screen": null,
-        "stand": null,
-        "system": "vacuum",
-        "type": "pcdsdevices.happi.containers.GateValve",
-        "z": 990.813
-    },
-    "HFX:DVD:VGC:01": {
-        "_id": "HFX:DVD:VGC:01",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "HXD",
-        "creation": "Thu Feb 15 17:52:07 2018",
-        "device_class": "pcdsdevices.device_types.GateValve",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Thu Feb 15 18:25:23 2018",
-        "lightpath": true,
-        "macros": null,
-        "name": "xrt_dvd_valve",
-        "parent": null,
-        "prefix": "HFX:DVD:VGC:01",
-        "screen": null,
-        "stand": null,
-        "system": "vacuum",
-        "type": "pcdsdevices.happi.containers.GateValve",
-        "z": 945.9630000000001
-    },
-    "HFX:MON:VGC:01": {
-        "_id": "HFX:MON:VGC:01",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "CXI",
-        "creation": "Thu Feb 15 17:52:07 2018",
-        "device_class": "pcdsdevices.device_types.GateValve",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Thu Feb 15 18:25:23 2018",
-        "macros": null,
-        "name": "hfx_mon_valve_1",
-        "parent": null,
-        "prefix": "HFX:MON:VGC:01",
-        "screen": null,
-        "stand": null,
-        "system": "vacuum",
-        "type": "pcdsdevices.happi.containers.GateValve",
-        "z": 969.209
-    },
-    "HFX:MON:VGC:02": {
-        "_id": "HFX:MON:VGC:02",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "CXI",
-        "creation": "Thu Feb 15 17:52:07 2018",
-        "device_class": "pcdsdevices.device_types.GateValve",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Thu Feb 15 18:25:23 2018",
-        "macros": null,
-        "name": "hfx_mon_valve_2",
-        "parent": null,
-        "prefix": "HFX:MON:VGC:02",
-        "screen": null,
-        "stand": null,
-        "system": "vacuum",
-        "type": "pcdsdevices.happi.containers.GateValve",
-        "z": 977.313
-    },
-    "HFX:MON:VGC:03": {
-        "_id": "HFX:MON:VGC:03",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "XCS",
-        "creation": "Thu Feb 15 17:52:07 2018",
-        "device_class": "pcdsdevices.device_types.GateValve",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Thu Feb 15 18:25:23 2018",
-        "macros": null,
-        "name": "hfx_mon_valve_3",
-        "parent": null,
-        "prefix": "HFX:MON:VGC:03",
-        "screen": null,
-        "stand": null,
-        "system": "vacuum",
-        "type": "pcdsdevices.happi.containers.GateValve",
-        "z": 969.209
-    },
-    "HX2:DVD:VGC:01": {
-        "_id": "HX2:DVD:VGC:01",
-        "active": false,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "HXD",
-        "creation": "Thu Feb 15 17:52:08 2018",
-        "device_class": "pcdsdevices.device_types.GateValve",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Thu Feb 15 18:25:23 2018",
-        "macros": null,
-        "name": "hx2_valve",
-        "parent": null,
-        "prefix": "HX2:DVD:VGC:01",
-        "screen": null,
-        "stand": null,
-        "system": "vacuum",
-        "type": "pcdsdevices.happi.containers.GateValve",
-        "z": 779.0
-    },
-    "HX2:REFLASER:MIRROR": {
-        "_id": "HX2:REFLASER:MIRROR",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "HXD",
-        "creation": "Tue Feb 27 11:51:31 2018",
-        "device_class": "pcdsdevices.inout.InOutRecordPositioner",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Feb 27 15:05:53 2018",
-        "lightpath": true,
-        "macros": null,
-        "name": "hx2_reference_laser",
-        "parent": null,
-        "prefix": "HX2:REFLASER:MIRROR",
-        "screen": null,
-        "stand": null,
-        "system": null,
-        "type": "pcdsdevices.happi.containers.Stopper",
-        "z": 778.4736
-    },
-    "HX2:SB1:IPM": {
-        "_id": "HX2:SB1:IPM",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "HXD",
-        "creation": "Tue Feb 27 11:40:14 2018",
-        "data": null,
-        "device_class": "pcdsdevices.device_types.IPM",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Feb 27 11:40:14 2018",
-        "lightpath": true,
-        "macros": null,
-        "name": "hx2_ipm",
-        "parent": null,
-        "prefix": "HX2:SB1:IPM",
-        "screen": null,
-        "stand": null,
-        "system": "diagnostic",
-        "type": "pcdsdevices.happi.containers.IPM",
-        "z": 778.8287
-    },
-    "HX2:SB1:JAWS": {
-        "_id": "HX2:SB1:JAWS",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "HXD",
-        "creation": "Tue Feb 27 10:41:25 2018",
-        "device_class": "pcdsdevices.device_types.Slits",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Feb 27 10:41:25 2018",
-        "lightpath": true,
-        "macros": null,
-        "name": "hx2_slits",
-        "parent": null,
-        "prefix": "HX2:SB1:JAWS",
-        "screen": null,
-        "stand": null,
-        "system": "beam control",
-        "type": "pcdsdevices.happi.containers.Slits",
-        "z": 778.6608
-    },
-    "HX2:SB1:PIM": {
-        "_id": "HX2:SB1:PIM",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "HXD",
-        "creation": "Tue Feb 27 12:56:05 2018",
-        "data": null,
-        "detailed_screen": null,
-        "device_class": "pcdsdevices.pim.PIM",
-        "documentation": null,
-        "embedded_screen": null,
-        "engineering_screen": null,
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Wed May 15 14:49:05 2019",
-        "lightpath": true,
-        "macros": null,
-        "name": "hx2_pim",
-        "parent": null,
-        "prefix": "HX2:SB1:PIM",
-        "prefix_det": null,
-        "screen": null,
-        "stand": null,
-        "system": "diagnostic",
-        "type": "pcdsdevices.happi.containers.PIM",
-        "z": 779.025
-    },
-    "HX2:UVD:VGC:01": {
-        "_id": "HX2:UVD:VGC:01",
-        "active": false,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "HXD",
-        "creation": "Thu Feb 15 17:52:08 2018",
-        "device_class": "pcdsdevices.device_types.GateValve",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Thu Feb 15 18:25:23 2018",
-        "macros": null,
-        "name": "uvd_valve",
-        "parent": null,
-        "prefix": "HX2:UVD:VGC:01",
-        "screen": null,
-        "stand": null,
-        "system": "vacuum",
-        "type": "pcdsdevices.happi.containers.GateValve",
-        "z": 769.0
-    },
-    "HX3:MON:VGC:01": {
-        "_id": "HX3:MON:VGC:01",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "HXD",
-        "creation": "Thu Feb 15 17:52:08 2018",
-        "device_class": "pcdsdevices.device_types.GateValve",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Thu Feb 15 18:25:23 2018",
-        "lightpath": true,
-        "macros": null,
-        "name": "hxd_mon_valve_1",
-        "parent": null,
-        "prefix": "HX3:MON:VGC:01",
-        "screen": null,
-        "stand": null,
-        "system": "vacuum",
-        "type": "pcdsdevices.happi.containers.GateValve",
-        "z": 782.5
-    },
-    "HX3:MON:VGC:02": {
-        "_id": "HX3:MON:VGC:02",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "HXD",
-        "creation": "Thu Feb 15 17:52:08 2018",
-        "device_class": "pcdsdevices.device_types.GateValve",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Thu Feb 15 18:25:23 2018",
-        "lightpath": true,
-        "macros": null,
-        "name": "hxd_mon_valve_2",
-        "parent": null,
-        "prefix": "HX3:MON:VGC:02",
-        "screen": null,
-        "stand": null,
-        "system": "vacuum",
-        "type": "pcdsdevices.happi.containers.GateValve",
-        "z": 783.5
-    },
-    "HXX:HXM:PIM": {
-        "_id": "HXX:HXM:PIM",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "HXD",
-        "creation": "Tue Feb 27 11:15:18 2018",
-        "device_class": "pcdsdevices.pim.PIMWithFocus",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Feb 27 11:15:18 2018",
-        "lightpath": true,
-        "macros": null,
-        "name": "mec_yag0",
-        "parent": null,
-        "prefix": "HXX:HXM:PIM",
-        "screen": null,
-        "stand": null,
-        "system": null,
-        "type": "pcdsdevices.happi.containers.LCLSItem",
-        "z": 818.416
-    },
-    "HXX:MXT:VGC:01": {
-        "_id": "HXX:MXT:VGC:01",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "HXD",
-        "creation": "Thu Feb 15 17:52:08 2018",
-        "device_class": "pcdsdevices.device_types.GateValve",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Thu Feb 15 18:25:23 2018",
-        "lightpath": true,
-        "macros": null,
-        "name": "mxt_valve_1",
-        "parent": null,
-        "prefix": "HXX:MXT:VGC:01",
-        "screen": null,
-        "stand": null,
-        "system": "vacuum",
-        "type": "pcdsdevices.happi.containers.GateValve",
-        "z": 812.8689999999999
-    },
-    "HXX:MXT:VGC:02": {
-        "_id": "HXX:MXT:VGC:02",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "HXD",
-        "creation": "Thu Feb 15 17:52:08 2018",
-        "device_class": "pcdsdevices.device_types.GateValve",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Thu Feb 15 18:25:23 2018",
-        "lightpath": true,
-        "macros": null,
-        "name": "mxt_valve_2",
-        "parent": null,
-        "prefix": "HXX:MXT:VGC:02",
-        "screen": null,
-        "stand": null,
-        "system": "vacuum",
-        "type": "pcdsdevices.happi.containers.GateValve",
-        "z": 818.2
-    },
-    "HXX:MXT:VGC:03": {
-        "_id": "HXX:MXT:VGC:03",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "HXD",
-        "creation": "Thu Feb 15 17:52:08 2018",
-        "device_class": "pcdsdevices.device_types.GateValve",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Thu Feb 15 18:25:23 2018",
-        "lightpath": true,
-        "macros": null,
-        "name": "xrt_mxt_valve",
-        "parent": null,
-        "prefix": "HXX:MXT:VGC:03",
-        "screen": null,
-        "stand": null,
-        "system": "vacuum",
-        "type": "pcdsdevices.happi.containers.GateValve",
-        "z": 870.97
-    },
-    "HXX:MXT:VGC:04": {
-        "_id": "HXX:MXT:VGC:04",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "MFX",
-        "creation": "Thu Feb 15 17:52:08 2018",
-        "device_class": "pcdsdevices.device_types.GateValve",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Thu Feb 15 18:25:23 2018",
-        "macros": null,
-        "name": "mfx_mxt_valve",
-        "parent": null,
-        "prefix": "HXX:MXT:VGC:04",
-        "screen": null,
-        "stand": null,
-        "system": "vacuum",
-        "type": "pcdsdevices.happi.containers.GateValve",
-        "z": 870.96
-    },
-    "HXX:MXT:VGC:05": {
-        "_id": "HXX:MXT:VGC:05",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "MEC",
-        "creation": "Thu Feb 15 17:52:08 2018",
-        "device_class": "pcdsdevices.device_types.GateValve",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Thu Feb 15 18:25:24 2018",
-        "macros": null,
-        "name": "mec_mxt_valve",
-        "parent": null,
-        "prefix": "HXX:MXT:VGC:05",
-        "screen": null,
-        "stand": null,
-        "system": "vacuum",
-        "type": "pcdsdevices.happi.containers.GateValve",
-        "z": 870.96
-    },
-    "HXX:UM6:IPM": {
-        "_id": "HXX:UM6:IPM",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "HXD",
-        "creation": "Tue Feb 27 11:40:15 2018",
-        "data": null,
-        "device_class": "pcdsdevices.device_types.IPM",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Feb 27 11:40:15 2018",
-        "lightpath": true,
-        "macros": null,
-        "name": "um6_ipm",
-        "parent": null,
-        "prefix": "HXX:UM6:IPM",
-        "screen": null,
-        "stand": null,
-        "system": "diagnostic",
-        "type": "pcdsdevices.happi.containers.IPM",
-        "z": 810.332
-    },
-    "HXX:UM6:JAWS": {
-        "_id": "HXX:UM6:JAWS",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "HXD",
-        "creation": "Tue Feb 27 10:41:25 2018",
-        "device_class": "pcdsdevices.device_types.Slits",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Feb 27 10:41:25 2018",
-        "lightpath": true,
-        "macros": null,
-        "name": "um6_slits",
-        "parent": null,
-        "prefix": "HXX:UM6:JAWS",
-        "screen": null,
-        "stand": null,
-        "system": "beam control",
-        "type": "pcdsdevices.happi.containers.Slits",
-        "z": 809.966
-    },
-    "HXX:UM6:PIM": {
-        "_id": "HXX:UM6:PIM",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "HXD",
-        "creation": "Tue Feb 27 11:15:18 2018",
-        "device_class": "pcdsdevices.pim.PIMWithLED",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Feb 27 11:15:18 2018",
-        "lightpath": true,
-        "macros": null,
-        "name": "um6_pim",
-        "parent": null,
-        "prefix": "HXX:UM6:PIM",
-        "screen": null,
-        "stand": null,
-        "system": null,
-        "type": "pcdsdevices.happi.containers.LCLSItem",
-        "z": 810.135
-    },
-    "HXX:UM6:STP:01": {
-        "_id": "HXX:UM6:STP:01",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "HXD",
-        "creation": "Tue Feb 27 11:46:45 2018",
-        "device_class": "pcdsdevices.device_types.Stopper",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Feb 27 15:08:45 2018",
-        "lightpath": true,
-        "macros": null,
-        "name": "um6_stopper",
-        "parent": null,
-        "prefix": "HXX:UM6:STP:01",
-        "screen": null,
-        "stand": null,
-        "system": null,
-        "type": "pcdsdevices.happi.containers.Stopper",
-        "z": 811.035
-    },
-    "MEC:ATT": {
-        "_id": "MEC:ATT",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "MEC",
-        "creation": "Tue Feb 27 11:38:15 2018",
-        "device_class": "pcdsdevices.device_types.Attenuator",
-        "kwargs": {
-            "n_filters": "{{n_filters}}",
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Feb 27 11:38:15 2018",
-        "macros": null,
-        "n_filters": 10,
-        "name": "mec_attenuator",
-        "parent": null,
-        "prefix": "MEC:ATT",
-        "screen": null,
-        "stand": null,
-        "system": "beam control",
-        "type": "pcdsdevices.happi.containers.Attenuator",
-        "z": 981.2
-    },
-    "MEC:BXL:VGC:01": {
-        "_id": "MEC:BXL:VGC:01",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "MEC",
-        "creation": "Thu Feb 15 17:52:08 2018",
-        "device_class": "pcdsdevices.device_types.GateValve",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Thu Feb 15 18:25:24 2018",
-        "macros": null,
-        "name": "mec_bxl_valve",
-        "parent": null,
-        "prefix": "MEC:BXL:VGC:01",
-        "screen": null,
-        "stand": null,
-        "system": "vacuum",
-        "type": "pcdsdevices.happi.containers.GateValve",
-        "z": 979.0
-    },
-    "MEC:HXM:MMS:18": {
-        "_id": "MEC:HXM:MMS:18",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "MEC",
-        "creation": "Tue Feb 27 11:31:29 2018",
-        "device_class": "pcdsdevices.device_types.PulsePicker",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Feb 27 11:31:29 2018",
-        "macros": null,
-        "name": "mec_pulsepicker",
-        "parent": null,
-        "prefix": "MEC:HXM:MMS:18",
-        "screen": null,
-        "stand": null,
-        "system": "beam control",
-        "type": "pcdsdevices.happi.containers.PulsePicker",
-        "z": 981.01
-    },
-    "MEC:HXM:VGC:01": {
-        "_id": "MEC:HXM:VGC:01",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "MEC",
-        "creation": "Thu Feb 15 17:52:08 2018",
-        "device_class": "pcdsdevices.device_types.GateValve",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Thu Feb 15 18:25:24 2018",
-        "macros": null,
-        "name": "mec_hxm_valve",
-        "parent": null,
-        "prefix": "MEC:HXM:VGC:01",
-        "screen": null,
-        "stand": null,
-        "system": "vacuum",
-        "type": "pcdsdevices.happi.containers.GateValve",
-        "z": 990.5
-    },
-    "MEC:IPM1": {
-        "_id": "MEC:IPM1",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "MEC",
-        "creation": "Tue Feb 27 11:40:15 2018",
-        "data": null,
-        "device_class": "pcdsdevices.device_types.IPM",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Feb 27 11:40:15 2018",
-        "macros": null,
-        "name": "mec_ipm1",
-        "parent": null,
-        "prefix": "MEC:IPM1",
-        "screen": null,
-        "stand": null,
-        "system": "diagnostic",
-        "type": "pcdsdevices.happi.containers.IPM",
-        "z": 990.2
-    },
-    "MEC:PIM1": {
-        "_id": "MEC:PIM1",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "MEC",
-        "creation": "Tue Feb 27 11:15:18 2018",
-        "device_class": "pcdsdevices.pim.PIM",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Feb 27 11:15:18 2018",
-        "macros": null,
-        "name": "mec_pim1",
-        "parent": null,
-        "prefix": "MEC:PIM1",
-        "screen": null,
-        "stand": null,
-        "system": null,
-        "type": "pcdsdevices.happi.containers.LCLSItem",
-        "z": 981.4
-    },
-    "MFX:ATT": {
-        "_id": "MFX:ATT",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "MFX",
-        "creation": "Mon Jan 29 13:49:27 2018",
-        "device_class": "pcdsdevices.device_types.Attenuator",
-        "kwargs": {
-            "n_filters": "{{n_filters}}",
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Feb 27 10:21:22 2018",
-        "macros": null,
-        "n_filters": 10,
-        "name": "mfx_attenuator",
-        "parent": null,
-        "prefix": "MFX:ATT",
-        "screen": null,
-        "stand": "DIA",
-        "system": "beam control",
-        "type": "pcdsdevices.happi.containers.Attenuator",
-        "z": 984.4
-    },
-    "MFX:DG1:IPM": {
-        "_id": "MFX:DG1:IPM",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "MFX",
-        "creation": "Tue Mar 26 10:49:16 2019",
-        "detailed_screen": null,
-        "device_class": "pcdsdevices.device_types.IPM",
-        "documentation": null,
-        "embedded_screen": null,
-        "engineering_screen": null,
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Wed Mar 27 09:56:09 2019",
-        "lightpath": false,
-        "macros": null,
-        "name": "mfx_dg1_ipm",
-        "parent": null,
-        "prefix": "MFX:DG1:IPM",
-        "stand": "DG1",
-        "system": "diagnostic",
-        "type": "pcdsdevices.happi.containers.IPM",
-        "z": 1019.59
-    },
-    "MFX:DG1:JAWS": {
-        "_id": "MFX:DG1:JAWS",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "MFX",
-        "creation": "Mon Jan 29 10:50:42 2018",
-        "device_class": "pcdsdevices.device_types.Slits",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Feb 27 10:21:22 2018",
-        "macros": null,
-        "name": "mfx_dg1_slits",
-        "parent": null,
-        "prefix": "MFX:DG1:JAWS",
-        "screen": null,
-        "stand": "DG1",
-        "system": "beam control",
-        "type": "pcdsdevices.happi.containers.Slits",
-        "z": 1019.3
-    },
-    "MFX:DG1:MMS:08": {
-        "_id": "MFX:DG1:MMS:08",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "MFX",
-        "creation": "Fri Sep 14 14:21:35 2018",
-        "device_class": "pcdsdevices.device_types.IMS",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Fri Sep 14 14:21:35 2018",
-        "macros": null,
-        "name": "mfx_dg1_wave8_motor",
-        "parent": null,
-        "prefix": "MFX:DG1:MMS:08",
-        "screen": null,
-        "stand": "DG1",
-        "system": null,
-        "type": "pcdsdevices.happi.containers.LCLSItem",
-        "z": -1.0
-    },
-    "MFX:DG1:PIM": {
-        "_id": "MFX:DG1:PIM",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "MFX",
-        "creation": "Mon Jan 29 14:04:28 2018",
-        "data": null,
-        "device_class": "pcdsdevices.pim.PIMWithLED",
-        "kwargs": {
-            "name": "{{name}}",
-            "prefix_det": "{{prefix_det}}"
-        },
-        "last_edit": "Tue Feb 27 10:21:22 2018",
-        "macros": null,
-        "name": "mfx_dg1_pim",
-        "parent": null,
-        "prefix": "MFX:DG1:PIM",
-        "prefix_det": "MFX:DG1:P6740",
-        "screen": null,
-        "stand": "DG1",
-        "system": "diagnostic",
-        "type": "pcdsdevices.happi.containers.PIM",
-        "z": 1019.79
-    },
-    "MFX:DG1:RLM:MIRROR": {
-        "_id": "MFX:DG1:RLM:MIRROR",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "MFX",
-        "creation": "Mon Jan 29 13:53:19 2018",
-        "detailed_screen": null,
-        "device_class": "pcdsdevices.inout.InOutRecordPositioner",
-        "documentation": null,
-        "embedded_screen": null,
-        "engineering_screen": null,
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue May  7 09:41:46 2019",
-        "lightpath": false,
-        "macros": null,
-        "name": "mfx_reflaser",
-        "parent": null,
-        "prefix": "MFX:DG1:RLM:MIRROR",
-        "screen": null,
-        "stand": "DG1",
-        "system": null,
-        "type": "pcdsdevices.happi.containers.LCLSItem",
-        "z": 1018.82
-    },
-    "MFX:DG1:VGC:01": {
-        "_id": "MFX:DG1:VGC:01",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "MFX",
-        "creation": "Tue Feb 27 10:25:17 2018",
-        "device_class": "pcdsdevices.device_types.GateValve",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Feb 27 10:26:30 2018",
-        "macros": null,
-        "name": "mfx_dg1_valve_1",
-        "parent": null,
-        "prefix": "MFX:DG1:VGC:01",
-        "screen": null,
-        "stand": "DG1",
-        "system": "vacuum",
-        "type": "pcdsdevices.happi.containers.GateValve",
-        "z": 1018.54
-    },
-    "MFX:DG1:VGC:02": {
-        "_id": "MFX:DG1:VGC:02",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "MFX",
-        "creation": "Tue Feb 27 10:26:03 2018",
-        "device_class": "pcdsdevices.device_types.GateValve",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Feb 27 10:26:03 2018",
-        "macros": null,
-        "name": "mfx_dg1_valve_2",
-        "parent": null,
-        "prefix": "MFX:DG1:VGC:02",
-        "screen": null,
-        "stand": "DG1",
-        "system": "vacuum",
-        "type": "pcdsdevices.happi.containers.GateValve",
-        "z": 1019.99
-    },
-    "MFX:DG2:IPM": {
-        "_id": "MFX:DG2:IPM",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "MFX",
-        "creation": "Wed Mar 27 09:53:48 2019",
-        "data": null,
-        "detailed_screen": null,
-        "device_class": "pcdsdevices.device_types.IPM",
-        "documentation": null,
-        "embedded_screen": null,
-        "engineering_screen": null,
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Wed Mar 27 09:53:48 2019",
-        "lightpath": false,
-        "macros": null,
-        "name": "mfx_dg2_ipm",
-        "parent": null,
-        "prefix": "MFX:DG2:IPM",
-        "stand": "DG2",
-        "system": "diagnostic",
-        "type": "pcdsdevices.happi.containers.IPM",
-        "z": 1021.54
-    },
-    "MFX:DG2:JAWS:DS": {
-        "_id": "MFX:DG2:JAWS:DS",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "MFX",
-        "creation": "Mon Jan 29 14:33:08 2018",
-        "device_class": "pcdsdevices.device_types.Slits",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Feb 27 10:21:22 2018",
-        "macros": null,
-        "name": "mfx_dg2_downstream_slits",
-        "parent": null,
-        "prefix": "MFX:DG2:JAWS:DS",
-        "screen": null,
-        "stand": "DG2",
-        "system": "beam control",
-        "type": "pcdsdevices.happi.containers.Slits",
-        "z": 1022.99
-    },
-    "MFX:DG2:JAWS:MS": {
-        "_id": "MFX:DG2:JAWS:MS",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "MFX",
-        "creation": "Mon Jan 29 14:32:42 2018",
-        "device_class": "pcdsdevices.device_types.Slits",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Feb 27 10:21:22 2018",
-        "macros": null,
-        "name": "mfx_dg2_midstream_slits",
-        "parent": null,
-        "prefix": "MFX:DG2:JAWS:MS",
-        "screen": null,
-        "stand": "DG2",
-        "system": "beam control",
-        "type": "pcdsdevices.happi.containers.Slits",
-        "z": 1022.84
-    },
-    "MFX:DG2:JAWS:US": {
-        "_id": "MFX:DG2:JAWS:US",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "MFX",
-        "creation": "Mon Jan 29 14:32:11 2018",
-        "device_class": "pcdsdevices.device_types.Slits",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Feb 27 10:21:22 2018",
-        "macros": null,
-        "name": "mfx_dg2_upstream_slits",
-        "parent": null,
-        "prefix": "MFX:DG2:JAWS:US",
-        "screen": null,
-        "stand": "DG2",
-        "system": "beam control",
-        "type": "pcdsdevices.happi.containers.Slits",
-        "z": 1021.29
-    },
-    "MFX:DG2:PIM": {
-        "_id": "MFX:DG2:PIM",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "MFX",
-        "creation": "Mon Jan 29 14:25:39 2018",
-        "data": null,
-        "device_class": "pcdsdevices.pim.PIMWithBoth",
-        "kwargs": {
-            "name": "{{name}}",
-            "prefix_det": "{{prefix_det}}"
-        },
-        "last_edit": "Tue Feb 27 10:21:22 2018",
-        "macros": null,
-        "name": "mfx_dg2_pim",
-        "parent": null,
-        "prefix": "MFX:DG2:PIM",
-        "prefix_det": "MFX:DG2:P6740",
-        "screen": null,
-        "stand": "DG2",
-        "system": "diagnostic",
-        "type": "pcdsdevices.happi.containers.PIM",
-        "z": 1021.74
-    },
-    "MFX:DIA:IPM": {
-        "_id": "MFX:DIA:IPM",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "MFX",
-        "creation": "Mon Jan 29 14:38:42 2018",
-        "data": null,
-        "detailed_screen": null,
-        "device_class": "pcdsdevices.device_types.IPM",
-        "documentation": null,
-        "embedded_screen": null,
-        "engineering_screen": null,
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue May  7 15:55:30 2019",
-        "lightpath": false,
-        "macros": null,
-        "name": "mfx_dia_ipm",
-        "parent": null,
-        "prefix": "MFX:DIA:IPM",
-        "screen": null,
-        "stand": "DIA",
-        "system": "diagnostic",
-        "type": "pcdsdevices.happi.containers.IPM",
-        "z": 984.85
-    },
-    "MFX:DIA:MMS:07": {
-        "_id": "MFX:DIA:MMS:07",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "MFX",
-        "creation": "Mon Jan 29 13:47:39 2018",
-        "device_class": "pcdsdevices.device_types.PulsePicker",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Feb 27 16:59:49 2018",
-        "macros": null,
-        "name": "mfx_pulsepicker",
-        "parent": null,
-        "prefix": "MFX:DIA:MMS:07",
-        "screen": null,
-        "stand": "DIA",
-        "system": "beam control",
-        "type": "pcdsdevices.happi.containers.PulsePicker",
-        "z": 984.2
-    },
-    "MFX:DIA:PIM": {
-        "_id": "MFX:DIA:PIM",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "MFX",
-        "creation": "Mon Jan 29 14:02:41 2018",
-        "data": null,
-        "detailed_screen": null,
-        "device_class": "pcdsdevices.pim.PIMWithFocus",
-        "documentation": null,
-        "embedded_screen": null,
-        "engineering_screen": null,
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue May  7 09:56:26 2019",
-        "lightpath": false,
-        "macros": null,
-        "name": "mfx_dia_pim",
-        "parent": null,
-        "prefix": "MFX:DIA:PIM",
-        "prefix_det": "MFX:DIA:CVV:01",
-        "screen": null,
-        "stand": "DIA",
-        "system": "diagnostic",
-        "type": "pcdsdevices.happi.containers.PIM",
-        "z": 984.9
-    },
-    "MFX:DIA:VGC:01": {
-        "_id": "MFX:DIA:VGC:01",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "MFX",
-        "creation": "Thu Feb 15 17:52:08 2018",
-        "device_class": "pcdsdevices.device_types.GateValve",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Wed May 16 14:23:19 2018",
-        "macros": null,
-        "name": "mfx_dia_valve_01",
-        "parent": null,
-        "prefix": "MFX:DIA:VGC:01",
-        "screen": null,
-        "stand": "DIA",
-        "system": "vacuum",
-        "type": "pcdsdevices.happi.containers.GateValve",
-        "z": 983.0
-    },
-    "MFX:DIA:VGC:02": {
-        "_id": "MFX:DIA:VGC:02",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "MFX",
-        "creation": "Thu Feb 15 17:52:08 2018",
-        "detailed_screen": null,
-        "device_class": "pcdsdevices.device_types.GateValve",
-        "documentation": null,
-        "embedded_screen": null,
-        "engineering_screen": null,
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Mar 26 10:11:33 2019",
-        "lightpath": false,
-        "macros": null,
-        "name": "mfx_dia_valve_02",
-        "parent": null,
-        "prefix": "MFX:DIA:VGC:02",
-        "screen": null,
-        "stand": null,
-        "system": "vacuum",
-        "type": "pcdsdevices.happi.containers.GateValve",
-        "z": 990.1
-    },
-    "MFX:DVD:VGC:01": {
-        "_id": "MFX:DVD:VGC:01",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "MFX",
-        "creation": "Thu Feb 15 17:52:08 2018",
-        "device_class": "pcdsdevices.device_types.GateValve",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Thu Feb 15 18:25:24 2018",
-        "macros": null,
-        "name": "mfx_dvd_valve",
-        "parent": null,
-        "prefix": "MFX:DVD:VGC:01",
-        "screen": null,
-        "stand": null,
-        "system": "vacuum",
-        "type": "pcdsdevices.happi.containers.GateValve",
-        "z": 945.9630000000001
-    },
-    "PPS:FEH1:45:S45STPRSUM": {
-        "_id": "PPS:FEH1:45:S45STPRSUM",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "MFX",
-        "creation": "Mon Jan 29 13:59:33 2018",
-        "device_class": "pcdsdevices.valve.PPSStopper",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Feb 27 10:21:22 2018",
-        "macros": null,
-        "name": "sh45",
-        "parent": null,
-        "prefix": "PPS:FEH1:45:S45STPRSUM",
-        "screen": null,
-        "stand": null,
-        "system": null,
-        "type": "pcdsdevices.happi.containers.LCLSItem",
-        "z": 952.2
-    },
-    "PPS:FEH1:4:S4STPRSUM": {
-        "_id": "PPS:FEH1:4:S4STPRSUM",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "XCS",
-        "creation": "Tue Feb 27 10:46:52 2018",
-        "device_class": "pcdsdevices.valve.PPSStopper",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Feb 27 10:46:52 2018",
-        "macros": null,
-        "name": "sh4",
-        "parent": null,
-        "prefix": "PPS:FEH1:4:S4STPRSUM",
-        "screen": null,
-        "stand": null,
-        "system": null,
-        "type": "pcdsdevices.happi.containers.LCLSItem",
-        "z": 1000.5
-    },
-    "PPS:FEH1:5:S5STPRSUM": {
-        "_id": "PPS:FEH1:5:S5STPRSUM",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "CXI",
-        "creation": "Tue Feb 27 10:46:52 2018",
-        "device_class": "pcdsdevices.valve.PPSStopper",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Feb 27 10:46:52 2018",
-        "macros": null,
-        "name": "sh5",
-        "parent": null,
-        "prefix": "PPS:FEH1:5:S5STPRSUM",
-        "screen": null,
-        "stand": null,
-        "system": null,
-        "type": "pcdsdevices.happi.containers.LCLSItem",
-        "z": 979.0
-    },
-    "PPS:FEH1:6:S6STPRSUM": {
-        "_id": "PPS:FEH1:6:S6STPRSUM",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "MEC",
-        "creation": "Tue Feb 27 10:46:53 2018",
-        "device_class": "pcdsdevices.valve.PPSStopper",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Feb 27 10:46:53 2018",
-        "macros": null,
-        "name": "sh6",
-        "parent": null,
-        "prefix": "PPS:FEH1:6:S6STPRSUM",
-        "screen": null,
-        "stand": null,
-        "system": null,
-        "type": "pcdsdevices.happi.containers.LCLSItem",
-        "z": 987.1
-    },
-    "PPS:NEH1:1:SH1INSUM": {
-        "_id": "PPS:NEH1:1:SH1INSUM",
-        "active": false,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "HXD",
-        "creation": "Tue Feb 27 10:46:53 2018",
-        "device_class": "pcdsdevices.valve.PPSStopper",
-        "kwargs": {
-            "name": "{{name}}",
-            "out_state": "NOT_IN"
-        },
-        "last_edit": "Tue Feb 27 10:47:44 2018",
-        "macros": null,
-        "name": "sh1",
-        "parent": null,
-        "prefix": "PPS:NEH1:1:SH1INSUM",
-        "screen": null,
-        "stand": null,
-        "system": null,
-        "type": "pcdsdevices.happi.containers.LCLSItem",
-        "z": 755.421
-    },
-    "STPR:XRT1:1:SH2_PPSSUM": {
-        "_id": "STPR:XRT1:1:SH2_PPSSUM",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "HXD",
-        "creation": "Tue Feb 27 10:46:53 2018",
-        "device_class": "pcdsdevices.valve.PPSStopper",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Feb 27 10:46:53 2018",
-        "lightpath": true,
-        "macros": null,
-        "name": "sh2",
-        "parent": null,
-        "prefix": "STPR:XRT1:1:SH2_PPSSUM",
-        "screen": null,
-        "stand": null,
-        "system": null,
-        "type": "pcdsdevices.happi.containers.LCLSItem",
-        "z": 803.1
-    },
-    "XCS:ATT": {
-        "_id": "XCS:ATT",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "XCS",
-        "creation": "Tue Feb 27 11:38:15 2018",
-        "detailed_screen": null,
-        "device_class": "pcdsdevices.device_types.Attenuator",
-        "documentation": null,
-        "embedded_screen": null,
-        "engineering_screen": null,
-        "kwargs": {
-            "n_filters": "{{n_filters}}",
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue May  7 16:24:57 2019",
-        "lightpath": false,
-        "macros": null,
-        "n_filters": 10,
-        "name": "xcs_attenuator",
-        "parent": null,
-        "prefix": "XCS:ATT",
-        "screen": null,
-        "stand": null,
-        "system": "beam control",
-        "type": "pcdsdevices.happi.containers.Attenuator",
-        "z": 1002.326
-    },
-    "XCS:DG3:IPM": {
-        "_id": "XCS:DG3:IPM",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "XCS",
-        "creation": "Tue Feb 27 11:40:15 2018",
-        "data": null,
-        "detailed_screen": null,
-        "device_class": "pcdsdevices.device_types.IPM",
-        "documentation": null,
-        "embedded_screen": null,
-        "engineering_screen": null,
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue May  7 15:44:25 2019",
-        "lightpath": false,
-        "macros": null,
-        "name": "xcs_dg3_ipm",
-        "parent": null,
-        "prefix": "XCS:DG3:IPM",
-        "screen": null,
-        "stand": null,
-        "system": "diagnostic",
-        "type": "pcdsdevices.happi.containers.IPM",
-        "z": 979.0
-    },
-    "XCS:DG3:JAWS": {
-        "_id": "XCS:DG3:JAWS",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "XCS",
-        "creation": "Tue Feb 27 10:41:25 2018",
-        "device_class": "pcdsdevices.device_types.Slits",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Feb 27 10:41:25 2018",
-        "macros": null,
-        "name": "xcs_dg3_slits",
-        "parent": null,
-        "prefix": "XCS:DG3:JAWS",
-        "screen": null,
-        "stand": null,
-        "system": "beam control",
-        "type": "pcdsdevices.happi.containers.Slits",
-        "z": 978.813
-    },
-    "XCS:DG3:PIM": {
-        "_id": "XCS:DG3:PIM",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "XCS",
-        "creation": "Tue Feb 27 11:15:19 2018",
-        "detailed_screen": null,
-        "device_class": "pcdsdevices.pim.PIMWithLED",
-        "documentation": null,
-        "embedded_screen": null,
-        "engineering_screen": null,
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue May  7 15:43:49 2019",
-        "lightpath": false,
-        "macros": null,
-        "name": "xcs_dg3_pim",
-        "parent": null,
-        "prefix": "XCS:DG3:PIM",
-        "screen": null,
-        "stand": null,
-        "system": null,
-        "type": "pcdsdevices.happi.containers.LCLSItem",
-        "z": 979.2
-    },
-    "XCS:DG3:VGC:02": {
-        "_id": "XCS:DG3:VGC:02",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "XCS",
-        "creation": "Thu Feb 15 18:21:13 2018",
-        "device_class": "pcdsdevices.device_types.GateValve",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Thu Feb 15 18:25:24 2018",
-        "macros": null,
-        "name": "xcs_dg3_valve_2",
-        "parent": null,
-        "prefix": "XCS:DG3:VGC:02",
-        "screen": null,
-        "stand": null,
-        "system": "vacuum",
-        "type": "pcdsdevices.happi.containers.GateValve",
-        "z": 990.913
-    },
-    "XCS:LAM:VGC:01": {
-        "_id": "XCS:LAM:VGC:01",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "XCS",
-        "creation": "Thu Feb 15 18:21:13 2018",
-        "device_class": "pcdsdevices.device_types.GateValve",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Thu Feb 15 18:25:24 2018",
-        "macros": null,
-        "name": "xcs_lam_valve_1",
-        "parent": null,
-        "prefix": "XCS:LAM:VGC:01",
-        "screen": null,
-        "stand": null,
-        "system": "vacuum",
-        "type": "pcdsdevices.happi.containers.GateValve",
-        "z": 1008.0
-    },
-    "XCS:LAM:VGC:02": {
-        "_id": "XCS:LAM:VGC:02",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "XCS",
-        "creation": "Thu Feb 15 18:21:13 2018",
-        "device_class": "pcdsdevices.device_types.GateValve",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Thu Feb 15 18:25:24 2018",
-        "macros": null,
-        "name": "xcs_lam_valve_2",
-        "parent": null,
-        "prefix": "XCS:LAM:VGC:02",
-        "screen": null,
-        "stand": null,
-        "system": "vacuum",
-        "type": "pcdsdevices.happi.containers.GateValve",
-        "z": 1009.0
-    },
-    "XCS:LODCM": {
-        "_id": "XCS:LODCM",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "HXD",
-        "creation": "Tue Feb 27 12:53:14 2018",
-        "device_class": "pcdsdevices.device_types.LODCM",
-        "kwargs": {
-            "main_line": "{{beamline}}",
-            "mono_line": "{{mono_line}}",
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Feb 27 12:53:14 2018",
-        "lightpath": true,
-        "macros": null,
-        "mono_line": "XCS",
-        "name": "xcs_lodcm",
-        "parent": null,
-        "prefix": "XCS:LODCM",
-        "screen": null,
-        "stand": null,
-        "system": "beam control",
-        "type": "pcdsdevices.happi.containers.LODCM",
-        "z": 964.76
-    },
-    "XCS:MON:IPM": {
-        "_id": "XCS:MON:IPM",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "XCS",
-        "creation": "Tue Feb 27 11:40:15 2018",
-        "data": null,
-        "device_class": "pcdsdevices.device_types.IPM",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Feb 27 11:40:15 2018",
-        "macros": null,
-        "name": "xcs_mon_ipm",
-        "parent": null,
-        "prefix": "XCS:MON:IPM",
-        "screen": null,
-        "stand": null,
-        "system": "diagnostic",
-        "type": "pcdsdevices.happi.containers.IPM",
-        "z": 971.0
-    },
-    "XCS:MON:VGC:04": {
-        "_id": "XCS:MON:VGC:04",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "XCS",
-        "creation": "Thu Feb 15 18:21:13 2018",
-        "device_class": "pcdsdevices.device_types.GateValve",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Thu Feb 15 18:25:24 2018",
-        "macros": null,
-        "name": "hfx_mon_valve_4",
-        "parent": null,
-        "prefix": "XCS:MON:VGC:04",
-        "screen": null,
-        "stand": null,
-        "system": "vacuum",
-        "type": "pcdsdevices.happi.containers.GateValve",
-        "z": 977.313
-    },
-    "XCS:PBT:PIM": {
-        "_id": "XCS:PBT:PIM",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "PBT",
-        "creation": "Tue Feb 27 11:15:19 2018",
-        "detailed_screen": null,
-        "device_class": "pcdsdevices.pim.PIMWithFocus",
-        "documentation": null,
-        "embedded_screen": null,
-        "engineering_screen": null,
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue May  7 15:47:17 2019",
-        "lightpath": false,
-        "macros": null,
-        "name": "xcs_pbt_pim",
-        "parent": null,
-        "prefix": "XCS:PBT:PIM",
-        "screen": null,
-        "stand": null,
-        "system": null,
-        "type": "pcdsdevices.happi.containers.LCLSItem",
-        "z": 930.6
-    },
-    "XCS:PBT:VGC:01": {
-        "_id": "XCS:PBT:VGC:01",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "PBT",
-        "creation": "Thu Feb 15 18:21:13 2018",
-        "device_class": "pcdsdevices.device_types.GateValve",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Thu Feb 15 18:25:24 2018",
-        "macros": null,
-        "name": "xcs_pbt_valve_1",
-        "parent": null,
-        "prefix": "XCS:PBT:VGC:01",
-        "screen": null,
-        "stand": null,
-        "system": "vacuum",
-        "type": "pcdsdevices.happi.containers.GateValve",
-        "z": 870.96
-    },
-    "XCS:PBT:VGC:02": {
-        "_id": "XCS:PBT:VGC:02",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "PBT",
-        "creation": "Thu Feb 15 18:21:13 2018",
-        "device_class": "pcdsdevices.device_types.GateValve",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Thu Feb 15 18:25:24 2018",
-        "macros": null,
-        "name": "xcs_pbt_valve_2",
-        "parent": null,
-        "prefix": "XCS:PBT:VGC:02",
-        "screen": null,
-        "stand": null,
-        "system": "vacuum",
-        "type": "pcdsdevices.happi.containers.GateValve",
-        "z": 925.9
-    },
-    "XCS:PBT:VGC:03": {
-        "_id": "XCS:PBT:VGC:03",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "PBT",
-        "creation": "Thu Feb 15 18:21:13 2018",
-        "device_class": "pcdsdevices.device_types.GateValve",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Thu Feb 15 18:25:24 2018",
-        "macros": null,
-        "name": "xcs_pbt_valve_3",
-        "parent": null,
-        "prefix": "XCS:PBT:VGC:03",
-        "screen": null,
-        "stand": null,
-        "system": "vacuum",
-        "type": "pcdsdevices.happi.containers.GateValve",
-        "z": 930.4
-    },
-    "XCS:PBT:VGC:04": {
-        "_id": "XCS:PBT:VGC:04",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "PBT",
-        "creation": "Thu Feb 15 18:21:13 2018",
-        "device_class": "pcdsdevices.device_types.GateValve",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Thu Feb 15 18:25:24 2018",
-        "macros": null,
-        "name": "xcs_pbt_valve_4",
-        "parent": null,
-        "prefix": "XCS:PBT:VGC:04",
-        "screen": null,
-        "stand": null,
-        "system": "vacuum",
-        "type": "pcdsdevices.happi.containers.GateValve",
-        "z": 961.3
-    },
-    "XCS:REFLASER1:MIRROR": {
-        "_id": "XCS:REFLASER1:MIRROR",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "HXD",
-        "creation": "Tue Feb 27 11:51:31 2018",
-        "device_class": "pcdsdevices.inout.InOutRecordPositioner",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Feb 27 15:05:53 2018",
-        "lightpath": true,
-        "macros": null,
-        "name": "xcs_reference_laser",
-        "parent": null,
-        "prefix": "XCS:REFLASER1:MIRROR",
-        "screen": null,
-        "stand": null,
-        "system": null,
-        "type": "pcdsdevices.happi.containers.Stopper",
-        "z": 958.497
-    },
-    "XCS:SB1:IPM": {
-        "_id": "XCS:SB1:IPM",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "XCS",
-        "creation": "Tue Feb 27 11:40:15 2018",
-        "data": null,
-        "detailed_screen": null,
-        "device_class": "pcdsdevices.device_types.IPM",
-        "documentation": null,
-        "embedded_screen": null,
-        "engineering_screen": null,
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue May  7 15:36:21 2019",
-        "lightpath": false,
-        "macros": null,
-        "name": "xcs_sb1_ipm",
-        "parent": null,
-        "prefix": "XCS:SB1:IPM",
-        "screen": null,
-        "stand": null,
-        "system": "diagnostic",
-        "type": "pcdsdevices.happi.containers.IPM",
-        "z": 1005.49
-    },
-    "XCS:SB1:JAWS": {
-        "_id": "XCS:SB1:JAWS",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "XCS",
-        "creation": "Tue Feb 27 10:41:25 2018",
-        "device_class": "pcdsdevices.device_types.Slits",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Feb 27 10:41:25 2018",
-        "macros": null,
-        "name": "xcs_sb1_slits",
-        "parent": null,
-        "prefix": "XCS:SB1:JAWS",
-        "screen": null,
-        "stand": null,
-        "system": "beam control",
-        "type": "pcdsdevices.happi.containers.Slits",
-        "z": 996.0
-    },
-    "XCS:SB1:PIM": {
-        "_id": "XCS:SB1:PIM",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "XCS",
-        "creation": "Tue Feb 27 11:15:19 2018",
-        "detailed_screen": null,
-        "device_class": "pcdsdevices.pim.PIMWithLED",
-        "documentation": null,
-        "embedded_screen": null,
-        "engineering_screen": null,
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue May  7 15:37:45 2019",
-        "lightpath": false,
-        "macros": null,
-        "name": "xcs_sb1_pim",
-        "parent": null,
-        "prefix": "XCS:SB1:PIM",
-        "screen": null,
-        "stand": null,
-        "system": null,
-        "type": "pcdsdevices.happi.containers.LCLSItem",
-        "z": 996.4
-    },
-    "XCS:SB1:STP:01": {
-        "_id": "XCS:SB1:STP:01",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "XCS",
-        "creation": "Tue Feb 27 11:46:45 2018",
-        "device_class": "pcdsdevices.device_types.Stopper",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Feb 27 15:05:26 2018",
-        "macros": null,
-        "name": "xcs_sb1_stopper",
-        "parent": null,
-        "prefix": "XCS:SB1:STP:01",
-        "screen": null,
-        "stand": null,
-        "system": null,
-        "type": "pcdsdevices.happi.containers.Stopper",
-        "z": 995.6
-    },
-    "XCS:SB1:VGC:01": {
-        "_id": "XCS:SB1:VGC:01",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "XCS",
-        "creation": "Thu Feb 15 18:21:13 2018",
-        "device_class": "pcdsdevices.device_types.GateValve",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Thu Feb 15 18:25:24 2018",
-        "macros": null,
-        "name": "xcs_sb1_valve",
-        "parent": null,
-        "prefix": "XCS:SB1:VGC:01",
-        "screen": null,
-        "stand": null,
-        "system": "vacuum",
-        "type": "pcdsdevices.happi.containers.GateValve",
-        "z": 1000.2
-    },
-    "XCS:SB2:DS:JAWS": {
-        "_id": "XCS:SB2:DS:JAWS",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "XCS",
-        "creation": "Tue Feb 27 10:41:25 2018",
-        "detailed_screen": null,
-        "device_class": "pcdsdevices.device_types.Slits",
-        "documentation": null,
-        "embedded_screen": null,
-        "engineering_screen": null,
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue May  7 15:41:05 2019",
-        "lightpath": false,
-        "macros": null,
-        "name": "xcs_sb2_downstream_slits",
-        "parent": null,
-        "prefix": "XCS:SB2:DS:JAWS",
-        "screen": null,
-        "stand": null,
-        "system": "beam control",
-        "type": "pcdsdevices.happi.containers.Slits",
-        "z": 1005.29
-    },
-    "XCS:SB2:IPM": {
-        "_id": "XCS:SB2:IPM",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "XCS",
-        "creation": "Tue Feb 27 11:40:15 2018",
-        "data": null,
-        "detailed_screen": null,
-        "device_class": "pcdsdevices.device_types.IPM",
-        "documentation": null,
-        "embedded_screen": null,
-        "engineering_screen": null,
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue May  7 15:33:12 2019",
-        "lightpath": false,
-        "macros": null,
-        "name": "xcs_sb2_ipm",
-        "parent": null,
-        "prefix": "XCS:SB2:IPM",
-        "screen": null,
-        "stand": null,
-        "system": "diagnostic",
-        "type": "pcdsdevices.happi.containers.IPM",
-        "z": 1005.49
-    },
-    "XCS:SB2:MMS:09": {
-        "_id": "XCS:SB2:MMS:09",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "XCS",
-        "creation": "Tue Feb 27 11:31:29 2018",
-        "device_class": "pcdsdevices.device_types.PulsePicker",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Feb 27 11:31:29 2018",
-        "macros": null,
-        "name": "xcs_pulsepicker",
-        "parent": null,
-        "prefix": "XCS:SB2:MMS:09",
-        "screen": null,
-        "stand": null,
-        "system": "beam control",
-        "type": "pcdsdevices.happi.containers.PulsePicker",
-        "z": 1002.0
-    },
-    "XCS:SB2:PIM": {
-        "_id": "XCS:SB2:PIM",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "XCS",
-        "creation": "Tue Feb 27 11:15:19 2018",
-        "detailed_screen": null,
-        "device_class": "pcdsdevices.pim.PIMWithLED",
-        "documentation": null,
-        "embedded_screen": null,
-        "engineering_screen": null,
-        "kwargs": {
-            "name": "{{name}}",
-            "prefix_det": "{{prefix_det}}"
-        },
-        "last_edit": "Fri May 17 11:44:12 2019",
-        "lightpath": false,
-        "macros": null,
-        "name": "xcs_sb2_pim",
-        "parent": null,
-        "prefix": "XCS:SB2:PIM",
-        "prefix_det": "XCS:GIGE:04:",
-        "screen": null,
-        "stand": null,
-        "system": null,
-        "type": "pcdsdevices.happi.containers.LCLSItem",
-        "z": 1005.72
-    },
-    "XCS:SB2:US:JAWS": {
-        "_id": "XCS:SB2:US:JAWS",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "XCS",
-        "creation": "Tue Feb 27 10:41:25 2018",
-        "detailed_screen": null,
-        "device_class": "pcdsdevices.device_types.Slits",
-        "documentation": null,
-        "embedded_screen": null,
-        "engineering_screen": null,
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue May  7 15:41:32 2019",
-        "lightpath": false,
-        "macros": null,
-        "name": "xcs_sb2_upstream_slits",
-        "parent": null,
-        "prefix": "XCS:SB2:US:JAWS",
-        "screen": null,
-        "stand": null,
-        "system": "beam control",
-        "type": "pcdsdevices.happi.containers.Slits",
-        "z": 1005.11
-    },
-    "XCS:SB2:VGC:01": {
-        "_id": "XCS:SB2:VGC:01",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "XCS",
-        "creation": "Thu Feb 15 18:21:13 2018",
-        "device_class": "pcdsdevices.device_types.GateValve",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Thu Feb 15 18:25:24 2018",
-        "macros": null,
-        "name": "xcs_sb2_vgc_01",
-        "parent": null,
-        "prefix": "XCS:SB2:VGC:01",
-        "screen": null,
-        "stand": null,
-        "system": "vacuum",
-        "type": "pcdsdevices.happi.containers.GateValve",
-        "z": 1002.0
-    },
-    "XCS:XFLS": {
-        "_id": "XCS:XFLS",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "XCS",
-        "creation": "Tue Feb 27 14:44:36 2018",
-        "device_class": "pcdsdevices.device_types.XFLS",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Feb 27 14:44:36 2018",
-        "macros": null,
-        "name": "xcs_xfls",
-        "parent": null,
-        "prefix": "XCS:XFLS",
-        "screen": null,
-        "stand": null,
-        "system": null,
-        "type": "pcdsdevices.happi.containers.LCLSItem",
-        "z": 1002.9780000000001
-    },
-    "XPP:ATT": {
-        "_id": "XPP:ATT",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "XPP",
-        "creation": "Tue Feb 27 11:38:16 2018",
-        "detailed_screen": null,
-        "device_class": "pcdsdevices.device_types.Attenuator",
-        "documentation": null,
-        "embedded_screen": null,
-        "engineering_screen": null,
-        "kwargs": {
-            "n_filters": "{{n_filters}}",
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue May  7 16:25:30 2019",
-        "lightpath": true,
-        "macros": null,
-        "n_filters": 10,
-        "name": "xpp_attenuator",
-        "parent": null,
-        "prefix": "XPP:ATT",
-        "screen": null,
-        "stand": null,
-        "system": "beam control",
-        "type": "pcdsdevices.happi.containers.Attenuator",
-        "z": 786.0
-    },
-    "XPP:LAS:MMN:04": {
-        "_id": "XPP:LAS:MMN:04",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "XPP",
-        "creation": "Tue Jul 17 09:52:23 2018",
-        "device_class": "pcdsdevices.device_types.Newport",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Jul 17 16:03:33 2018",
-        "macros": null,
-        "name": "xpp_las_delay",
-        "parent": null,
-        "prefix": "XPP:LAS:MMN:04",
-        "screen": null,
-        "stand": null,
-        "system": null,
-        "type": "pcdsdevices.happi.containers.LCLSItem",
-        "z": -1.0
-    },
-    "XPP:LAS:MMN:05": {
-        "_id": "XPP:LAS:MMN:05",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "XPP",
-        "creation": "Tue Jul 17 10:39:07 2018",
-        "device_class": "pcdsdevices.device_types.Newport",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Jul 17 10:41:22 2018",
-        "macros": null,
-        "name": "xpp_las_lensv",
-        "parent": null,
-        "prefix": "XPP:LAS:MMN:05",
-        "screen": null,
-        "stand": null,
-        "system": null,
-        "type": "pcdsdevices.happi.containers.LCLSItem",
-        "z": -1.0
-    },
-    "XPP:LAS:MMN:06": {
-        "_id": "XPP:LAS:MMN:06",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "XPP",
-        "creation": "Tue Jul 17 11:14:47 2018",
-        "device_class": "pcdsdevices.device_types.Newport",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Jul 17 16:05:15 2018",
-        "macros": null,
-        "name": "xpp_las_lensh",
-        "parent": null,
-        "prefix": "XPP:LAS:MMN:06",
-        "screen": null,
-        "stand": null,
-        "system": null,
-        "type": "pcdsdevices.happi.containers.LCLSItem",
-        "z": -1.0
-    },
-    "XPP:LAS:MMN:08": {
-        "_id": "XPP:LAS:MMN:08",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "XPP",
-        "creation": "Tue Jul 17 12:32:43 2018",
-        "device_class": "pcdsdevices.device_types.Newport",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Jul 17 12:32:43 2018",
-        "macros": null,
-        "name": "xpp_las_lensf",
-        "parent": null,
-        "prefix": "XPP:LAS:MMN:08",
-        "screen": null,
-        "stand": null,
-        "system": null,
-        "type": "pcdsdevices.happi.containers.LCLSItem",
-        "z": -1.0
-    },
-    "XPP:LAS:MMN:13": {
-        "_id": "XPP:LAS:MMN:13",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "XPP",
-        "creation": "Tue Jul 17 12:35:03 2018",
-        "device_class": "pcdsdevices.device_types.Newport",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Jul 17 12:35:03 2018",
-        "macros": null,
-        "name": "xpp_las_tt_lensh",
-        "parent": null,
-        "prefix": "XPP:LAS:MMN:13",
-        "screen": null,
-        "stand": null,
-        "system": null,
-        "type": "pcdsdevices.happi.containers.LCLSItem",
-        "z": -1.0
-    },
-    "XPP:LAS:MMN:14": {
-        "_id": "XPP:LAS:MMN:14",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "XPP",
-        "creation": "Tue Jul 17 12:38:30 2018",
-        "device_class": "pcdsdevices.device_types.Newport",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Jul 17 12:38:30 2018",
-        "macros": null,
-        "name": "xpp_las_tt_lensv",
-        "parent": null,
-        "prefix": "XPP:LAS:MMN:14",
-        "screen": null,
-        "stand": null,
-        "system": null,
-        "type": "pcdsdevices.happi.containers.LCLSItem",
-        "z": -1.0
-    },
-    "XPP:LAS:MMN:15": {
-        "_id": "XPP:LAS:MMN:15",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "XPP",
-        "creation": "Tue Jul 17 12:38:51 2018",
-        "device_class": "pcdsdevices.device_types.Newport",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Jul 17 12:38:51 2018",
-        "macros": null,
-        "name": "xpp_las_tt_lensf",
-        "parent": null,
-        "prefix": "XPP:LAS:MMN:15",
-        "screen": null,
-        "stand": null,
-        "system": null,
-        "type": "pcdsdevices.happi.containers.LCLSItem",
-        "z": -1.0
-    },
-    "XPP:LODCM": {
-        "_id": "XPP:LODCM",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "HXD",
-        "creation": "Tue Feb 27 12:53:14 2018",
-        "device_class": "pcdsdevices.device_types.LODCM",
-        "kwargs": {
-            "main_line": "{{beamline}}",
-            "mono_line": "{{mono_line}}",
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Feb 27 12:53:14 2018",
-        "lightpath": true,
-        "macros": null,
-        "mono_line": "XPP",
-        "name": "xpp_lodcm",
-        "parent": null,
-        "prefix": "XPP:LODCM",
-        "screen": null,
-        "stand": null,
-        "system": "beam control",
-        "type": "pcdsdevices.happi.containers.LODCM",
-        "z": 781.1
-    },
-    "XPP:SB2:IPM": {
-        "_id": "XPP:SB2:IPM",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "XPP",
-        "creation": "Tue Feb 27 11:40:15 2018",
-        "data": null,
-        "device_class": "pcdsdevices.device_types.IPM",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Feb 27 11:40:15 2018",
-        "lightpath": true,
-        "macros": null,
-        "name": "xpp_sb2_ipm",
-        "parent": null,
-        "prefix": "XPP:SB2:IPM",
-        "screen": null,
-        "stand": null,
-        "system": "diagnostic",
-        "type": "pcdsdevices.happi.containers.IPM",
-        "z": 784.132
-    },
-    "XPP:SB2:MMS:29": {
-        "_id": "XPP:SB2:MMS:29",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "XPP",
-        "creation": "Tue Feb 27 11:31:29 2018",
-        "device_class": "pcdsdevices.device_types.PulsePicker",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Feb 27 11:31:29 2018",
-        "lightpath": true,
-        "macros": null,
-        "name": "xpp_pulsepicker",
-        "parent": null,
-        "prefix": "XPP:SB2:MMS:29",
-        "screen": null,
-        "stand": null,
-        "system": "beam control",
-        "type": "pcdsdevices.happi.containers.PulsePicker",
-        "z": 785.574
-    },
-    "XPP:SB2:VGC:01": {
-        "_id": "XPP:SB2:VGC:01",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "XPP",
-        "creation": "Thu Feb 15 18:21:13 2018",
-        "device_class": "pcdsdevices.device_types.GateValve",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Thu Feb 15 18:25:24 2018",
-        "lightpath": true,
-        "macros": null,
-        "name": "xpp_sb2_valve",
-        "parent": null,
-        "prefix": "XPP:SB2:VGC:01",
-        "screen": null,
-        "stand": null,
-        "system": "vacuum",
-        "type": "pcdsdevices.happi.containers.GateValve",
-        "z": 784.132
-    },
-    "XPP:SB2:XFLS": {
-        "_id": "XPP:SB2:XFLS",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "XPP",
-        "creation": "Tue Feb 27 14:44:36 2018",
-        "device_class": "pcdsdevices.device_types.XFLS",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Feb 27 14:44:36 2018",
-        "lightpath": true,
-        "macros": null,
-        "name": "xpp_xfls",
-        "parent": null,
-        "prefix": "XPP:SB2:XFLS",
-        "screen": null,
-        "stand": null,
-        "system": null,
-        "type": "pcdsdevices.happi.containers.LCLSItem",
-        "z": 784.9830000000001
-    },
-    "XPP:SB2H:JAWS": {
-        "_id": "XPP:SB2H:JAWS",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "XPP",
-        "creation": "Tue Feb 27 10:41:25 2018",
-        "device_class": "pcdsdevices.device_types.Slits",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Feb 27 10:41:25 2018",
-        "lightpath": true,
-        "macros": null,
-        "name": "xpp_sb2_high_slits",
-        "parent": null,
-        "prefix": "XPP:SB2H:JAWS",
-        "screen": null,
-        "stand": null,
-        "system": "beam control",
-        "type": "pcdsdevices.happi.containers.Slits",
-        "z": 784.3860000000001
-    },
-    "XPP:SB2L:JAWS": {
-        "_id": "XPP:SB2L:JAWS",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "XPP",
-        "creation": "Tue Feb 27 10:41:25 2018",
-        "device_class": "pcdsdevices.device_types.Slits",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Feb 27 10:41:25 2018",
-        "lightpath": true,
-        "macros": null,
-        "name": "xpp_sb2_low_slits",
-        "parent": null,
-        "prefix": "XPP:SB2L:JAWS",
-        "screen": null,
-        "stand": null,
-        "system": "beam control",
-        "type": "pcdsdevices.happi.containers.Slits",
-        "z": 784.3860000000001
-    },
-    "XPP:SB3:IPM": {
-        "_id": "XPP:SB3:IPM",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "XPP",
-        "creation": "Tue Feb 27 11:40:15 2018",
-        "data": null,
-        "device_class": "pcdsdevices.device_types.IPM",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Feb 27 11:40:15 2018",
-        "lightpath": true,
-        "macros": null,
-        "name": "xpp_sb3_ipm",
-        "parent": null,
-        "prefix": "XPP:SB3:IPM",
-        "screen": null,
-        "stand": null,
-        "system": "diagnostic",
-        "type": "pcdsdevices.happi.containers.IPM",
-        "z": 787.655
-    },
-    "XPP:SB3:JAWS": {
-        "_id": "XPP:SB3:JAWS",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "XPP",
-        "creation": "Tue Feb 27 10:41:25 2018",
-        "device_class": "pcdsdevices.device_types.Slits",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Feb 27 10:41:25 2018",
-        "lightpath": true,
-        "macros": null,
-        "name": "xpp_sb3_slits",
-        "parent": null,
-        "prefix": "XPP:SB3:JAWS",
-        "screen": null,
-        "stand": null,
-        "system": "beam control",
-        "type": "pcdsdevices.happi.containers.Slits",
-        "z": 787.4860000000001
-    },
-    "XPP:SB3:PIM": {
-        "_id": "XPP:SB3:PIM",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "XPP",
-        "creation": "Tue Feb 27 11:15:19 2018",
-        "device_class": "pcdsdevices.pim.PIMWithFocus",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Feb 27 11:15:19 2018",
-        "lightpath": true,
-        "macros": null,
-        "name": "xpp_sb3_pim",
-        "parent": null,
-        "prefix": "XPP:SB3:PIM",
-        "screen": null,
-        "stand": null,
-        "system": null,
-        "type": "pcdsdevices.happi.containers.LCLSItem",
-        "z": 787.8
-    },
-    "XRT:DIA:ATT": {
-        "_id": "XRT:DIA:ATT",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "CXI",
-        "creation": "Tue Feb 27 11:38:16 2018",
-        "detailed_screen": null,
-        "device_class": "pcdsdevices.device_types.Attenuator",
-        "documentation": null,
-        "embedded_screen": null,
-        "engineering_screen": null,
-        "kwargs": {
-            "n_filters": "{{n_filters}}",
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue May  7 16:35:26 2019",
-        "lightpath": false,
-        "macros": null,
-        "n_filters": 10,
-        "name": "cxi_xrt_attenuator",
-        "parent": null,
-        "prefix": "XRT:DIA:ATT",
-        "screen": null,
-        "stand": null,
-        "system": "beam control",
-        "type": "pcdsdevices.happi.containers.Attenuator",
-        "z": 982.0
-    },
-    "XRT:DIA:MMS:16": {
-        "_id": "XRT:DIA:MMS:16",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "CXI",
-        "creation": "Tue Feb 27 11:31:29 2018",
-        "device_class": "pcdsdevices.device_types.PulsePicker",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Feb 27 11:31:29 2018",
-        "macros": null,
-        "name": "cxi_pulsepicker",
-        "parent": null,
-        "prefix": "XRT:DIA:MMS:16",
-        "screen": null,
-        "stand": null,
-        "system": "beam control",
-        "type": "pcdsdevices.happi.containers.PulsePicker",
-        "z": 981.8192
-    },
-    "XRT:M1H": {
-        "_id": "XRT:M1H",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "HXD",
-        "creation": "Tue Feb 27 16:06:20 2018",
-        "device_class": "pcdsdevices.mirror.PointingMirror",
-        "kwargs": {
-            "in_lines": [
-                "PBT"
-            ],
-            "name": "{{name}}",
-            "out_lines": [
-                "HXD",
-                "MFX",
-                "MEC"
-            ]
-        },
-        "last_edit": "Tue Feb 27 16:06:20 2018",
-        "lightpath": true,
-        "macros": null,
-        "name": "xrt_m1h",
-        "parent": null,
-        "prefix": "XRT:M1H",
-        "prefix_xy": null,
-        "screen": null,
-        "stand": null,
-        "system": "beam control",
-        "type": "pcdsdevices.happi.containers.OffsetMirror",
-        "xgantry_prefix": null,
-        "z": 814.716
-    },
-    "XRT:M2H": {
-        "_id": "XRT:M2H",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "HXD",
-        "creation": "Tue Feb 27 16:11:09 2018",
-        "device_class": "pcdsdevices.mirror.PointingMirror",
-        "kwargs": {
-            "in_lines": [
-                "MEC",
-                "MFX"
-            ],
-            "name": "{{name}}",
-            "out_lines": [
-                "HXD"
-            ]
-        },
-        "last_edit": "Tue Feb 27 16:11:09 2018",
-        "lightpath": true,
-        "macros": null,
-        "name": "xrt_m2h",
-        "parent": null,
-        "prefix": "XRT:M2H",
-        "prefix_xy": null,
-        "screen": null,
-        "stand": null,
-        "system": "beam control",
-        "type": "pcdsdevices.happi.containers.OffsetMirror",
-        "xgantry_prefix": null,
-        "z": 817.1160000000001
-    },
-    "XRT:M3H": {
-        "_id": "XRT:M3H",
-        "active": true,
-        "args": [
-            "{{prefix}}"
-        ],
-        "beamline": "PBT",
-        "creation": "Tue Feb 27 16:12:10 2018",
-        "device_class": "pcdsdevices.device_types.OffsetMirror",
-        "kwargs": {
-            "name": "{{name}}"
-        },
-        "last_edit": "Tue Feb 27 16:12:10 2018",
-        "macros": null,
-        "name": "xrt_m3h",
-        "parent": null,
-        "prefix": "XRT:M3H",
-        "prefix_xy": null,
-        "screen": null,
-        "stand": null,
-        "system": "beam control",
-        "type": "pcdsdevices.happi.containers.OffsetMirror",
-        "xgantry_prefix": null,
-        "z": 927.919
-    },
     "at1l0": {
         "_id": "at1l0",
         "active": true,
@@ -3991,6 +96,1132 @@
         "stand": null,
         "type": "pcdsdevices.happi.containers.LCLSItem",
         "z": 742.4427
+    },
+    "cxi_dg1_pim": {
+        "_id": "cxi_dg1_pim",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Tue Feb 27 12:56:05 2018",
+        "data": null,
+        "device_class": "pcdsdevices.pim.PIM",
+        "kwargs": {
+            "name": "{{name}}",
+            "prefix_det": "{{prefix_det}}"
+        },
+        "last_edit": "Thu Apr 12 14:39:09 2018",
+        "macros": null,
+        "name": "cxi_dg1_pim",
+        "parent": null,
+        "prefix": "CXI:DG1:PIM",
+        "prefix_det": "CXI:DG1:P6740",
+        "screen": null,
+        "stand": "DG1",
+        "system": "diagnostic",
+        "type": "pcdsdevices.happi.containers.PIM",
+        "z": 1035.8
+    },
+    "cxi_dg1_slits": {
+        "_id": "cxi_dg1_slits",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Tue Feb 27 10:41:25 2018",
+        "device_class": "pcdsdevices.device_types.Slits",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Apr 12 14:40:08 2018",
+        "macros": null,
+        "name": "cxi_dg1_slits",
+        "parent": null,
+        "prefix": "CXI:DG1:JAWS",
+        "screen": null,
+        "stand": "DG1",
+        "system": "beam control",
+        "type": "pcdsdevices.happi.containers.Slits",
+        "z": 1035.5
+    },
+    "cxi_dg1_vgc_01": {
+        "_id": "cxi_dg1_vgc_01",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Thu Apr 12 16:35:56 2018",
+        "device_class": "pcdsdevices.device_types.GateValve",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Apr 12 16:35:56 2018",
+        "macros": null,
+        "name": "cxi_dg1_vgc_01",
+        "parent": null,
+        "prefix": "CXI:DG1:VGC:01",
+        "screen": null,
+        "stand": "DG1",
+        "system": "vacuum",
+        "type": "pcdsdevices.happi.containers.GateValve",
+        "z": 1035.0
+    },
+    "cxi_dg1_vgc_02": {
+        "_id": "cxi_dg1_vgc_02",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Thu Apr 12 16:36:24 2018",
+        "device_class": "pcdsdevices.device_types.GateValve",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Apr 12 16:36:24 2018",
+        "macros": null,
+        "name": "cxi_dg1_vgc_02",
+        "parent": null,
+        "prefix": "CXI:DG1:VGC:02",
+        "screen": null,
+        "stand": "DG1",
+        "system": "vacuum",
+        "type": "pcdsdevices.happi.containers.GateValve",
+        "z": 1036.1
+    },
+    "cxi_dg2_ipm": {
+        "_id": "cxi_dg2_ipm",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Wed Apr 18 15:20:42 2018",
+        "data": null,
+        "device_class": "pcdsdevices.device_types.IPM",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Wed Apr 18 15:20:42 2018",
+        "macros": null,
+        "name": "cxi_dg2_ipm",
+        "parent": null,
+        "prefix": "CXI:DG2:IPM",
+        "screen": null,
+        "stand": "DG2",
+        "system": "diagnostic",
+        "type": "pcdsdevices.happi.containers.IPM",
+        "z": 1043.75
+    },
+    "cxi_dg2_jaws": {
+        "_id": "cxi_dg2_jaws",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Tue Feb 27 10:41:25 2018",
+        "device_class": "pcdsdevices.device_types.Slits",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Apr 12 14:55:27 2018",
+        "macros": null,
+        "name": "cxi_dg2_jaws",
+        "parent": null,
+        "prefix": "CXI:DG2:JAWS",
+        "screen": null,
+        "stand": "DG2",
+        "system": "beam control",
+        "type": "pcdsdevices.happi.containers.Slits",
+        "z": 1043.45
+    },
+    "cxi_dg2_lens_x": {
+        "_id": "cxi_dg2_lens_x",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Tue Aug 21 09:29:22 2018",
+        "device_class": "pcdsdevices.device_types.IMS",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Aug 21 09:29:22 2018",
+        "macros": null,
+        "name": "cxi_dg2_lens_x",
+        "parent": null,
+        "prefix": "CXI:DG2:MMS:05",
+        "screen": null,
+        "stand": "DG2",
+        "system": null,
+        "type": "pcdsdevices.happi.containers.LCLSItem",
+        "z": -1.0
+    },
+    "cxi_dg2_lens_y": {
+        "_id": "cxi_dg2_lens_y",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Tue Aug 21 09:29:45 2018",
+        "device_class": "pcdsdevices.device_types.IMS",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Aug 21 09:29:45 2018",
+        "macros": null,
+        "name": "cxi_dg2_lens_y",
+        "parent": null,
+        "prefix": "CXI:DG2:MMS:06",
+        "screen": null,
+        "stand": "DG2",
+        "system": null,
+        "type": "pcdsdevices.happi.containers.LCLSItem",
+        "z": -1.0
+    },
+    "cxi_dg2_pim": {
+        "_id": "cxi_dg2_pim",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Tue Feb 27 12:56:05 2018",
+        "data": null,
+        "device_class": "pcdsdevices.pim.PIM",
+        "kwargs": {
+            "name": "{{name}}",
+            "prefix_det": "{{prefix_det}}"
+        },
+        "last_edit": "Thu Apr 12 14:42:59 2018",
+        "macros": null,
+        "name": "cxi_dg2_pim",
+        "parent": null,
+        "prefix": "CXI:DG2:PIM",
+        "prefix_det": "CXI:DG2:P6740",
+        "screen": null,
+        "stand": "DG2",
+        "system": "diagnostic",
+        "type": "pcdsdevices.happi.containers.PIM",
+        "z": 1043.98
+    },
+    "cxi_dg2_vgc_01": {
+        "_id": "cxi_dg2_vgc_01",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Thu Apr 12 16:40:35 2018",
+        "device_class": "pcdsdevices.device_types.GateValve",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Apr 12 16:40:35 2018",
+        "macros": null,
+        "name": "cxi_dg2_vgc_01",
+        "parent": null,
+        "prefix": "CXI:DG2:VGC:01",
+        "screen": null,
+        "stand": "DG2",
+        "system": "vacuum",
+        "type": "pcdsdevices.happi.containers.GateValve",
+        "z": 1042.9
+    },
+    "cxi_dg2_vgc_02": {
+        "_id": "cxi_dg2_vgc_02",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Thu Apr 12 16:41:09 2018",
+        "device_class": "pcdsdevices.device_types.GateValve",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Apr 12 16:41:09 2018",
+        "macros": null,
+        "name": "cxi_dg2_vgc_02",
+        "parent": null,
+        "prefix": "CXI:DG2:VGC:02",
+        "screen": null,
+        "stand": "DG2",
+        "system": "vacuum",
+        "type": "pcdsdevices.happi.containers.GateValve",
+        "z": 1044.1
+    },
+    "cxi_dg2_xfls": {
+        "_id": "cxi_dg2_xfls",
+        "active": false,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Wed Apr 18 15:31:24 2018",
+        "device_class": "pcdsdevices.device_types.XFLS",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Wed Apr 18 15:40:55 2018",
+        "macros": null,
+        "name": "cxi_dg2_xfls",
+        "parent": null,
+        "prefix": "CXI:DG2:XFLS",
+        "screen": null,
+        "stand": "DG2",
+        "system": null,
+        "type": "pcdsdevices.happi.containers.LCLSItem",
+        "z": 1043.15
+    },
+    "cxi_dg3_ipm": {
+        "_id": "cxi_dg3_ipm",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Wed Apr 18 15:21:52 2018",
+        "data": null,
+        "device_class": "pcdsdevices.device_types.IPM",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Wed Apr 18 15:21:52 2018",
+        "macros": null,
+        "name": "cxi_dg3_ipm",
+        "parent": null,
+        "prefix": "CXI:DG3:IPM",
+        "screen": null,
+        "stand": "DG3",
+        "system": "diagnostic",
+        "type": "pcdsdevices.happi.containers.IPM",
+        "z": 1057.12
+    },
+    "cxi_dg3_pim": {
+        "_id": "cxi_dg3_pim",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Thu Apr 12 16:32:55 2018",
+        "device_class": "pcdsdevices.pim.PIMWithFocus",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Apr 12 16:32:55 2018",
+        "macros": null,
+        "name": "cxi_dg3_pim",
+        "parent": null,
+        "prefix": "CXI:DG3:PIM",
+        "screen": null,
+        "stand": "DG3",
+        "system": null,
+        "type": "pcdsdevices.happi.containers.LCLSItem",
+        "z": 1057.12
+    },
+    "cxi_dia_valve": {
+        "_id": "cxi_dia_valve",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Thu Feb 15 17:52:07 2018",
+        "device_class": "pcdsdevices.device_types.GateValve",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Feb 15 18:25:23 2018",
+        "macros": null,
+        "name": "cxi_dia_valve",
+        "parent": null,
+        "prefix": "HFX:DIA:VGC:01",
+        "screen": null,
+        "stand": null,
+        "system": "vacuum",
+        "type": "pcdsdevices.happi.containers.GateValve",
+        "z": 990.813
+    },
+    "cxi_ds1_att": {
+        "_id": "cxi_ds1_att",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Thu Apr 12 17:13:38 2018",
+        "device_class": "pcdsdevices.inout.InOutRecordPositioner",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Apr 12 17:13:38 2018",
+        "macros": null,
+        "name": "cxi_ds1_att",
+        "parent": null,
+        "prefix": "CXI:DS1:ATT:INOUT",
+        "screen": null,
+        "stand": "DS1",
+        "system": null,
+        "type": "pcdsdevices.happi.containers.LCLSItem",
+        "z": 1048.19
+    },
+    "cxi_ds1_pulsepicker": {
+        "_id": "cxi_ds1_pulsepicker",
+        "active": false,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Thu Apr 12 15:22:09 2018",
+        "device_class": "pcdsdevices.device_types.PulsePicker",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Sep 13 21:44:25 2018",
+        "macros": null,
+        "name": "cxi_ds1_pulsepicker",
+        "parent": null,
+        "prefix": "CXI:DS1:MMS:14",
+        "screen": null,
+        "stand": "DS1",
+        "system": "beam control",
+        "type": "pcdsdevices.happi.containers.PulsePicker",
+        "z": 1047.86
+    },
+    "cxi_ds1_xfls": {
+        "_id": "cxi_ds1_xfls",
+        "active": false,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Wed Apr 18 15:33:06 2018",
+        "device_class": "pcdsdevices.device_types.XFLS",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Wed Apr 18 15:40:36 2018",
+        "macros": null,
+        "name": "cxi_ds1_xfls",
+        "parent": null,
+        "prefix": "CXI:DS1:XFLS",
+        "screen": null,
+        "stand": "DS1",
+        "system": null,
+        "type": "pcdsdevices.happi.containers.LCLSItem",
+        "z": 1048.38
+    },
+    "cxi_dsb_attenuator": {
+        "_id": "cxi_dsb_attenuator",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Thu Apr 12 16:30:09 2018",
+        "detailed_screen": null,
+        "device_class": "pcdsdevices.device_types.Attenuator",
+        "documentation": null,
+        "embedded_screen": null,
+        "engineering_screen": null,
+        "kwargs": {
+            "n_filters": "{{n_filters}}",
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue May  7 16:35:57 2019",
+        "lightpath": false,
+        "macros": null,
+        "n_filters": 6,
+        "name": "cxi_dsb_attenuator",
+        "parent": null,
+        "prefix": "CXI:DSB:ATT",
+        "screen": null,
+        "stand": "DSB",
+        "system": "beam control",
+        "type": "pcdsdevices.happi.containers.Attenuator",
+        "z": 1045.21
+    },
+    "cxi_dsb_jaws": {
+        "_id": "cxi_dsb_jaws",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Tue Feb 27 10:41:25 2018",
+        "device_class": "pcdsdevices.device_types.Slits",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Apr 12 14:57:01 2018",
+        "macros": null,
+        "name": "cxi_dsb_jaws",
+        "parent": null,
+        "prefix": "CXI:DSB:JAWS",
+        "screen": null,
+        "stand": "DG2",
+        "system": "beam control",
+        "type": "pcdsdevices.happi.containers.Slits",
+        "z": 1045.71
+    },
+    "cxi_dsc_vgc_01": {
+        "_id": "cxi_dsc_vgc_01",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Mon Apr 16 11:34:36 2018",
+        "device_class": "pcdsdevices.device_types.GateValve",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Mon Apr 16 11:36:29 2018",
+        "macros": null,
+        "name": "cxi_dsc_vgc_01",
+        "parent": null,
+        "prefix": "CXI:DSC:VGC:01",
+        "screen": null,
+        "stand": "DSC",
+        "system": "vacuum",
+        "type": "pcdsdevices.happi.containers.GateValve",
+        "z": 1050.88
+    },
+    "cxi_kb1_hp": {
+        "_id": "cxi_kb1_hp",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Tue Aug 21 09:13:03 2018",
+        "device_class": "pcdsdevices.device_types.IMS",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Aug 21 09:23:32 2018",
+        "macros": null,
+        "name": "cxi_kb1_hp",
+        "parent": null,
+        "prefix": "CXI:KB1:MMS:07",
+        "screen": null,
+        "stand": "KB1",
+        "system": null,
+        "type": "pcdsdevices.happi.containers.LCLSItem",
+        "z": -1.0
+    },
+    "cxi_kb1_hr": {
+        "_id": "cxi_kb1_hr",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Tue Aug 21 09:14:56 2018",
+        "device_class": "pcdsdevices.device_types.IMS",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Aug 21 09:23:32 2018",
+        "macros": null,
+        "name": "cxi_kb1_hr",
+        "parent": null,
+        "prefix": "CXI:KB1:MMS:08",
+        "screen": null,
+        "stand": "KB1",
+        "system": null,
+        "type": "pcdsdevices.happi.containers.LCLSItem",
+        "z": -1.0
+    },
+    "cxi_kb1_hx": {
+        "_id": "cxi_kb1_hx",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Tue Aug 21 09:15:22 2018",
+        "device_class": "pcdsdevices.device_types.IMS",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Aug 21 09:23:32 2018",
+        "macros": null,
+        "name": "cxi_kb1_hx",
+        "parent": null,
+        "prefix": "CXI:KB1:MMS:05",
+        "screen": null,
+        "stand": "KB1",
+        "system": null,
+        "type": "pcdsdevices.happi.containers.LCLSItem",
+        "z": -1.0
+    },
+    "cxi_kb1_hy": {
+        "_id": "cxi_kb1_hy",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Tue Aug 21 09:15:39 2018",
+        "device_class": "pcdsdevices.device_types.IMS",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Aug 21 09:23:32 2018",
+        "macros": null,
+        "name": "cxi_kb1_hy",
+        "parent": null,
+        "prefix": "CXI:KB1:MMS:06",
+        "screen": null,
+        "stand": "KB1",
+        "system": null,
+        "type": "pcdsdevices.happi.containers.LCLSItem",
+        "z": -1.0
+    },
+    "cxi_kb1_jaws_ds": {
+        "_id": "cxi_kb1_jaws_ds",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Tue Feb 27 10:41:25 2018",
+        "device_class": "pcdsdevices.device_types.Slits",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Apr 12 14:49:28 2018",
+        "macros": null,
+        "name": "cxi_kb1_jaws_ds",
+        "parent": null,
+        "prefix": "CXI:KB1:JAWS:DS",
+        "screen": null,
+        "stand": "KB1",
+        "system": "beam control",
+        "type": "pcdsdevices.happi.containers.Slits",
+        "z": 1039.03
+    },
+    "cxi_kb1_slits_us": {
+        "_id": "cxi_kb1_slits_us",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Tue Feb 27 10:41:25 2018",
+        "device_class": "pcdsdevices.device_types.Slits",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Apr 12 14:48:00 2018",
+        "macros": null,
+        "name": "cxi_kb1_slits_us",
+        "parent": null,
+        "prefix": "CXI:KB1:JAWS:US",
+        "screen": null,
+        "stand": "KB1",
+        "system": "beam control",
+        "type": "pcdsdevices.happi.containers.Slits",
+        "z": 1036.85
+    },
+    "cxi_kb1_vgc_01": {
+        "_id": "cxi_kb1_vgc_01",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Thu Apr 12 16:37:08 2018",
+        "device_class": "pcdsdevices.device_types.GateValve",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Apr 12 16:38:12 2018",
+        "macros": null,
+        "name": "cxi_kb1_vgc_01",
+        "parent": null,
+        "prefix": "CXI:KB1:VGC:01",
+        "screen": null,
+        "stand": "KB1",
+        "system": "vacuum",
+        "type": "pcdsdevices.happi.containers.GateValve",
+        "z": 1037.15
+    },
+    "cxi_kb1_vgc_02": {
+        "_id": "cxi_kb1_vgc_02",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Thu Apr 12 16:37:34 2018",
+        "device_class": "pcdsdevices.device_types.GateValve",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Apr 12 16:37:34 2018",
+        "macros": null,
+        "name": "cxi_kb1_vgc_02",
+        "parent": null,
+        "prefix": "CXI:KB1:VGC:02",
+        "screen": null,
+        "stand": "KB1",
+        "system": "vacuum",
+        "type": "pcdsdevices.happi.containers.GateValve",
+        "z": 1038.7
+    },
+    "cxi_kb1_vp": {
+        "_id": "cxi_kb1_vp",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Tue Aug 21 09:13:37 2018",
+        "device_class": "pcdsdevices.device_types.IMS",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Aug 21 09:23:32 2018",
+        "macros": null,
+        "name": "cxi_kb1_vp",
+        "parent": null,
+        "prefix": "CXI:KB1:MMS:11",
+        "screen": null,
+        "stand": "KB1",
+        "system": null,
+        "type": "pcdsdevices.happi.containers.LCLSItem",
+        "z": -1.0
+    },
+    "cxi_kb1_vx": {
+        "_id": "cxi_kb1_vx",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Tue Aug 21 09:13:54 2018",
+        "device_class": "pcdsdevices.device_types.IMS",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Aug 21 09:23:32 2018",
+        "macros": null,
+        "name": "cxi_kb1_vx",
+        "parent": null,
+        "prefix": "CXI:KB1:MMS:09",
+        "screen": null,
+        "stand": "KB1",
+        "system": null,
+        "type": "pcdsdevices.happi.containers.LCLSItem",
+        "z": -1.0
+    },
+    "cxi_kb1_vy": {
+        "_id": "cxi_kb1_vy",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Tue Aug 21 09:14:34 2018",
+        "device_class": "pcdsdevices.device_types.IMS",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Aug 21 09:23:32 2018",
+        "macros": null,
+        "name": "cxi_kb1_vy",
+        "parent": null,
+        "prefix": "CXI:KB1:MMS:10",
+        "screen": null,
+        "stand": "KB1",
+        "system": null,
+        "type": "pcdsdevices.happi.containers.LCLSItem",
+        "z": -1.0
+    },
+    "cxi_kb2_hl": {
+        "_id": "cxi_kb2_hl",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Tue Aug 21 09:22:12 2018",
+        "device_class": "pcdsdevices.device_types.IMS",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Aug 21 09:23:32 2018",
+        "macros": null,
+        "name": "cxi_kb2_hl",
+        "parent": null,
+        "prefix": "CXI:KB2:MMS:03",
+        "screen": null,
+        "stand": "KB2",
+        "system": null,
+        "type": "pcdsdevices.happi.containers.LCLSItem",
+        "z": -1.0
+    },
+    "cxi_kb2_hp": {
+        "_id": "cxi_kb2_hp",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Tue Aug 21 09:17:51 2018",
+        "device_class": "pcdsdevices.device_types.IMS",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Aug 21 09:23:32 2018",
+        "macros": null,
+        "name": "cxi_kb2_hp",
+        "parent": null,
+        "prefix": "CXI:KB2:MMS:04",
+        "screen": null,
+        "stand": "KB2",
+        "system": null,
+        "type": "pcdsdevices.happi.containers.LCLSItem",
+        "z": -1.0
+    },
+    "cxi_kb2_hr": {
+        "_id": "cxi_kb2_hr",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Tue Aug 21 09:18:35 2018",
+        "device_class": "pcdsdevices.device_types.IMS",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Aug 21 09:23:32 2018",
+        "macros": null,
+        "name": "cxi_kb2_hr",
+        "parent": null,
+        "prefix": "CXI:KB2:MMS:05",
+        "screen": null,
+        "stand": "KB2",
+        "system": null,
+        "type": "pcdsdevices.happi.containers.LCLSItem",
+        "z": -1.0
+    },
+    "cxi_kb2_hx": {
+        "_id": "cxi_kb2_hx",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Tue Aug 21 09:20:23 2018",
+        "device_class": "pcdsdevices.device_types.IMS",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Aug 21 09:23:32 2018",
+        "macros": null,
+        "name": "cxi_kb2_hx",
+        "parent": null,
+        "prefix": "CXI:KB2:MMS:01",
+        "screen": null,
+        "stand": "KB2",
+        "system": null,
+        "type": "pcdsdevices.happi.containers.LCLSItem",
+        "z": -1.0
+    },
+    "cxi_kb2_hy": {
+        "_id": "cxi_kb2_hy",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Tue Aug 21 09:20:39 2018",
+        "device_class": "pcdsdevices.device_types.IMS",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Aug 21 09:23:32 2018",
+        "macros": null,
+        "name": "cxi_kb2_hy",
+        "parent": null,
+        "prefix": "CXI:KB2:MMS:02",
+        "screen": null,
+        "stand": "KB2",
+        "system": null,
+        "type": "pcdsdevices.happi.containers.LCLSItem",
+        "z": -1.0
+    },
+    "cxi_kb2_vgc_01": {
+        "_id": "cxi_kb2_vgc_01",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Thu Apr 12 16:38:57 2018",
+        "device_class": "pcdsdevices.device_types.GateValve",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Apr 12 16:38:57 2018",
+        "macros": null,
+        "name": "cxi_kb2_vgc_01",
+        "parent": null,
+        "prefix": "CXI:KB2:VGC:01",
+        "screen": null,
+        "stand": "KB2",
+        "system": "vacuum",
+        "type": "pcdsdevices.happi.containers.GateValve",
+        "z": 1039.27
+    },
+    "cxi_kb2_vp": {
+        "_id": "cxi_kb2_vp",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Tue Aug 21 09:18:12 2018",
+        "device_class": "pcdsdevices.device_types.IMS",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Aug 21 09:23:32 2018",
+        "macros": null,
+        "name": "cxi_kb2_vp",
+        "parent": null,
+        "prefix": "CXI:KB2:MMS:08",
+        "screen": null,
+        "stand": "KB2",
+        "system": null,
+        "type": "pcdsdevices.happi.containers.LCLSItem",
+        "z": -1.0
+    },
+    "cxi_kb2_vx": {
+        "_id": "cxi_kb2_vx",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Tue Aug 21 09:21:17 2018",
+        "device_class": "pcdsdevices.device_types.IMS",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Aug 21 09:23:32 2018",
+        "macros": null,
+        "name": "cxi_kb2_vx",
+        "parent": null,
+        "prefix": "CXI:KB2:MMS:06",
+        "screen": null,
+        "stand": "KB2",
+        "system": null,
+        "type": "pcdsdevices.happi.containers.LCLSItem",
+        "z": -1.0
+    },
+    "cxi_kb2_vy": {
+        "_id": "cxi_kb2_vy",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Tue Aug 21 09:21:22 2018",
+        "device_class": "pcdsdevices.device_types.IMS",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Aug 21 09:23:32 2018",
+        "macros": null,
+        "name": "cxi_kb2_vy",
+        "parent": null,
+        "prefix": "CXI:KB2:MMS:07",
+        "screen": null,
+        "stand": "KB2",
+        "system": null,
+        "type": "pcdsdevices.happi.containers.LCLSItem",
+        "z": -1.0
+    },
+    "cxi_pulsepicker": {
+        "_id": "cxi_pulsepicker",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Tue Feb 27 11:31:29 2018",
+        "device_class": "pcdsdevices.device_types.PulsePicker",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Feb 27 11:31:29 2018",
+        "macros": null,
+        "name": "cxi_pulsepicker",
+        "parent": null,
+        "prefix": "XRT:DIA:MMS:16",
+        "screen": null,
+        "stand": null,
+        "system": "beam control",
+        "type": "pcdsdevices.happi.containers.PulsePicker",
+        "z": 981.8192
+    },
+    "cxi_reflaser": {
+        "_id": "cxi_reflaser",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Thu Apr 12 16:06:42 2018",
+        "device_class": "pcdsdevices.inout.InOutRecordPositioner",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Apr 12 16:06:42 2018",
+        "macros": null,
+        "name": "cxi_reflaser",
+        "parent": null,
+        "prefix": "CXI:DG1:RLM:MIRROR",
+        "screen": null,
+        "stand": "DG1",
+        "system": null,
+        "type": "pcdsdevices.happi.containers.LCLSItem",
+        "z": 1035.2
+    },
+    "cxi_sc1_vgc_01": {
+        "_id": "cxi_sc1_vgc_01",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Mon Apr 16 11:38:59 2018",
+        "device_class": "pcdsdevices.device_types.GateValve",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Mon Apr 16 11:38:59 2018",
+        "macros": null,
+        "name": "cxi_sc1_vgc_01",
+        "parent": null,
+        "prefix": "CXI:SC1:VGC:01",
+        "screen": null,
+        "stand": "SC1",
+        "system": "vacuum",
+        "type": "pcdsdevices.happi.containers.GateValve",
+        "z": 1046.07
+    },
+    "cxi_sc1_vgc_02": {
+        "_id": "cxi_sc1_vgc_02",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Mon Apr 16 11:38:25 2018",
+        "device_class": "pcdsdevices.device_types.GateValve",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Mon Apr 16 11:38:25 2018",
+        "macros": null,
+        "name": "cxi_sc1_vgc_02",
+        "parent": null,
+        "prefix": "CXI:SC1:VGC:02",
+        "screen": null,
+        "stand": "SC1",
+        "system": "vacuum",
+        "type": "pcdsdevices.happi.containers.GateValve",
+        "z": 1047.32
+    },
+    "cxi_sc3_vgc_01": {
+        "_id": "cxi_sc3_vgc_01",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Mon Apr 16 11:35:24 2018",
+        "device_class": "pcdsdevices.device_types.GateValve",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Mon Apr 16 11:35:24 2018",
+        "macros": null,
+        "name": "cxi_sc3_vgc_01",
+        "parent": null,
+        "prefix": "CXI:SC3:VGC:01",
+        "screen": null,
+        "stand": "SC3",
+        "system": "vacuum",
+        "type": "pcdsdevices.happi.containers.GateValve",
+        "z": 1048.78
+    },
+    "cxi_snd_valve": {
+        "_id": "cxi_snd_valve",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Thu Feb 15 17:52:07 2018",
+        "device_class": "pcdsdevices.device_types.GateValve",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Feb 15 18:25:23 2018",
+        "macros": null,
+        "name": "cxi_snd_valve",
+        "parent": null,
+        "prefix": "HFA:SND:VGC:01",
+        "screen": null,
+        "stand": null,
+        "system": "vacuum",
+        "type": "pcdsdevices.happi.containers.GateValve",
+        "z": 996.61
+    },
+    "cxi_xrt_attenuator": {
+        "_id": "cxi_xrt_attenuator",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Tue Feb 27 11:38:16 2018",
+        "detailed_screen": null,
+        "device_class": "pcdsdevices.device_types.Attenuator",
+        "documentation": null,
+        "embedded_screen": null,
+        "engineering_screen": null,
+        "kwargs": {
+            "n_filters": "{{n_filters}}",
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue May  7 16:35:26 2019",
+        "lightpath": false,
+        "macros": null,
+        "n_filters": 10,
+        "name": "cxi_xrt_attenuator",
+        "parent": null,
+        "prefix": "XRT:DIA:ATT",
+        "screen": null,
+        "stand": null,
+        "system": "beam control",
+        "type": "pcdsdevices.happi.containers.Attenuator",
+        "z": 982.0
     },
     "em1l0": {
         "_id": "em1l0",
@@ -4095,6 +1326,447 @@
         "stand": null,
         "type": "pcdsdevices.happi.containers.LCLSItem",
         "z": 733.0
+    },
+    "fee_m1h": {
+        "_id": "fee_m1h",
+        "active": false,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "HXD",
+        "creation": "Tue Feb 27 15:50:33 2018",
+        "device_class": "pcdsdevices.device_types.OffsetMirror",
+        "kwargs": {
+            "name": "{{name}}",
+            "prefix_xy": "{{prefix_xy}}",
+            "xgantry_prefix": "{{xgantry_prefix}}"
+        },
+        "last_edit": "Tue Feb 27 15:50:33 2018",
+        "macros": null,
+        "name": "fee_m1h",
+        "parent": null,
+        "prefix": "FEE1:M1H",
+        "prefix_xy": "STEP:M1H",
+        "screen": null,
+        "stand": null,
+        "system": "beam control",
+        "type": "pcdsdevices.happi.containers.OffsetMirror",
+        "xgantry_prefix": "STEP:FEE1:611:MOTR",
+        "z": 740.51
+    },
+    "fee_m2h": {
+        "_id": "fee_m2h",
+        "active": false,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "HXD",
+        "creation": "Tue Feb 27 16:00:54 2018",
+        "device_class": "pcdsdevices.device_types.OffsetMirror",
+        "kwargs": {
+            "name": "{{name}}",
+            "prefix_xy": "{{prefix_xy}}",
+            "xgantry_prefix": "{{xgantry_prefix}}"
+        },
+        "last_edit": "Tue Feb 27 16:00:54 2018",
+        "macros": null,
+        "name": "fee_m2h",
+        "parent": null,
+        "prefix": "FEE1:M2H",
+        "prefix_xy": "STEP:M2H",
+        "screen": null,
+        "stand": null,
+        "system": "beam control",
+        "type": "pcdsdevices.happi.containers.OffsetMirror",
+        "xgantry_prefix": "STEP:FEE1:861:MOTR",
+        "z": 751.8430000000001
+    },
+    "hfx_mon_valve_1": {
+        "_id": "hfx_mon_valve_1",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Thu Feb 15 17:52:07 2018",
+        "device_class": "pcdsdevices.device_types.GateValve",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Feb 15 18:25:23 2018",
+        "macros": null,
+        "name": "hfx_mon_valve_1",
+        "parent": null,
+        "prefix": "HFX:MON:VGC:01",
+        "screen": null,
+        "stand": null,
+        "system": "vacuum",
+        "type": "pcdsdevices.happi.containers.GateValve",
+        "z": 969.209
+    },
+    "hfx_mon_valve_2": {
+        "_id": "hfx_mon_valve_2",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Thu Feb 15 17:52:07 2018",
+        "device_class": "pcdsdevices.device_types.GateValve",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Feb 15 18:25:23 2018",
+        "macros": null,
+        "name": "hfx_mon_valve_2",
+        "parent": null,
+        "prefix": "HFX:MON:VGC:02",
+        "screen": null,
+        "stand": null,
+        "system": "vacuum",
+        "type": "pcdsdevices.happi.containers.GateValve",
+        "z": 977.313
+    },
+    "hfx_mon_valve_3": {
+        "_id": "hfx_mon_valve_3",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "XCS",
+        "creation": "Thu Feb 15 17:52:07 2018",
+        "device_class": "pcdsdevices.device_types.GateValve",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Feb 15 18:25:23 2018",
+        "macros": null,
+        "name": "hfx_mon_valve_3",
+        "parent": null,
+        "prefix": "HFX:MON:VGC:03",
+        "screen": null,
+        "stand": null,
+        "system": "vacuum",
+        "type": "pcdsdevices.happi.containers.GateValve",
+        "z": 969.209
+    },
+    "hfx_mon_valve_4": {
+        "_id": "hfx_mon_valve_4",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "XCS",
+        "creation": "Thu Feb 15 18:21:13 2018",
+        "device_class": "pcdsdevices.device_types.GateValve",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Feb 15 18:25:24 2018",
+        "macros": null,
+        "name": "hfx_mon_valve_4",
+        "parent": null,
+        "prefix": "XCS:MON:VGC:04",
+        "screen": null,
+        "stand": null,
+        "system": "vacuum",
+        "type": "pcdsdevices.happi.containers.GateValve",
+        "z": 977.313
+    },
+    "hx2_ipm": {
+        "_id": "hx2_ipm",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "HXD",
+        "creation": "Tue Feb 27 11:40:14 2018",
+        "data": null,
+        "device_class": "pcdsdevices.device_types.IPM",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Feb 27 11:40:14 2018",
+        "lightpath": true,
+        "macros": null,
+        "name": "hx2_ipm",
+        "parent": null,
+        "prefix": "HX2:SB1:IPM",
+        "screen": null,
+        "stand": null,
+        "system": "diagnostic",
+        "type": "pcdsdevices.happi.containers.IPM",
+        "z": 778.8287
+    },
+    "hx2_pim": {
+        "_id": "hx2_pim",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "HXD",
+        "creation": "Tue Feb 27 12:56:05 2018",
+        "data": null,
+        "detailed_screen": null,
+        "device_class": "pcdsdevices.pim.PIM",
+        "documentation": null,
+        "embedded_screen": null,
+        "engineering_screen": null,
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Wed May 15 14:49:05 2019",
+        "lightpath": true,
+        "macros": null,
+        "name": "hx2_pim",
+        "parent": null,
+        "prefix": "HX2:SB1:PIM",
+        "prefix_det": null,
+        "screen": null,
+        "stand": null,
+        "system": "diagnostic",
+        "type": "pcdsdevices.happi.containers.PIM",
+        "z": 779.025
+    },
+    "hx2_reference_laser": {
+        "_id": "hx2_reference_laser",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "HXD",
+        "creation": "Tue Feb 27 11:51:31 2018",
+        "device_class": "pcdsdevices.inout.InOutRecordPositioner",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Feb 27 15:05:53 2018",
+        "lightpath": true,
+        "macros": null,
+        "name": "hx2_reference_laser",
+        "parent": null,
+        "prefix": "HX2:REFLASER:MIRROR",
+        "screen": null,
+        "stand": null,
+        "system": null,
+        "type": "pcdsdevices.happi.containers.Stopper",
+        "z": 778.4736
+    },
+    "hx2_slits": {
+        "_id": "hx2_slits",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "HXD",
+        "creation": "Tue Feb 27 10:41:25 2018",
+        "device_class": "pcdsdevices.device_types.Slits",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Feb 27 10:41:25 2018",
+        "lightpath": true,
+        "macros": null,
+        "name": "hx2_slits",
+        "parent": null,
+        "prefix": "HX2:SB1:JAWS",
+        "screen": null,
+        "stand": null,
+        "system": "beam control",
+        "type": "pcdsdevices.happi.containers.Slits",
+        "z": 778.6608
+    },
+    "hx2_valve": {
+        "_id": "hx2_valve",
+        "active": false,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "HXD",
+        "creation": "Thu Feb 15 17:52:08 2018",
+        "device_class": "pcdsdevices.device_types.GateValve",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Feb 15 18:25:23 2018",
+        "macros": null,
+        "name": "hx2_valve",
+        "parent": null,
+        "prefix": "HX2:DVD:VGC:01",
+        "screen": null,
+        "stand": null,
+        "system": "vacuum",
+        "type": "pcdsdevices.happi.containers.GateValve",
+        "z": 779.0
+    },
+    "hxd_dg2_ipm": {
+        "_id": "hxd_dg2_ipm",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "HXD",
+        "creation": "Tue Feb 27 11:40:14 2018",
+        "data": null,
+        "device_class": "pcdsdevices.device_types.IPM",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Feb 27 11:40:14 2018",
+        "lightpath": true,
+        "macros": null,
+        "name": "hxd_dg2_ipm",
+        "parent": null,
+        "prefix": "HFX:DG2:IPM",
+        "screen": null,
+        "stand": null,
+        "system": "diagnostic",
+        "type": "pcdsdevices.happi.containers.IPM",
+        "z": 958.8560000000001
+    },
+    "hxd_dg2_pim": {
+        "_id": "hxd_dg2_pim",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "HXD",
+        "creation": "Tue Feb 27 11:15:18 2018",
+        "device_class": "pcdsdevices.pim.PIM",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Feb 27 11:15:18 2018",
+        "lightpath": true,
+        "macros": null,
+        "name": "hxd_dg2_pim",
+        "parent": null,
+        "prefix": "HFX:DG2:PIM",
+        "screen": null,
+        "stand": null,
+        "system": null,
+        "type": "pcdsdevices.happi.containers.LCLSItem",
+        "z": 959.053
+    },
+    "hxd_dg2_slits": {
+        "_id": "hxd_dg2_slits",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "HXD",
+        "creation": "Tue Feb 27 10:41:25 2018",
+        "device_class": "pcdsdevices.device_types.Slits",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Feb 27 10:41:25 2018",
+        "lightpath": true,
+        "macros": null,
+        "name": "hxd_dg2_slits",
+        "parent": null,
+        "prefix": "HFX:DG2:JAWS",
+        "screen": null,
+        "stand": null,
+        "system": "beam control",
+        "type": "pcdsdevices.happi.containers.Slits",
+        "z": 958.689
+    },
+    "hxd_dg2_stopper": {
+        "_id": "hxd_dg2_stopper",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "HXD",
+        "creation": "Tue Feb 27 11:46:45 2018",
+        "device_class": "pcdsdevices.device_types.Stopper",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Feb 27 15:04:38 2018",
+        "lightpath": true,
+        "macros": null,
+        "name": "hxd_dg2_stopper",
+        "parent": null,
+        "prefix": "HFX:DG2:STP:01",
+        "screen": null,
+        "stand": null,
+        "system": null,
+        "type": "pcdsdevices.happi.containers.Stopper",
+        "z": 959.2
+    },
+    "hxd_dg2_valve": {
+        "_id": "hxd_dg2_valve",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "HXD",
+        "creation": "Thu Feb 15 17:52:07 2018",
+        "device_class": "pcdsdevices.device_types.GateValve",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Feb 15 18:25:23 2018",
+        "lightpath": true,
+        "macros": null,
+        "name": "hxd_dg2_valve",
+        "parent": null,
+        "prefix": "HFX:DG2:VGC:01",
+        "screen": null,
+        "stand": null,
+        "system": "vacuum",
+        "type": "pcdsdevices.happi.containers.GateValve",
+        "z": 959.441
+    },
+    "hxd_mon_valve_1": {
+        "_id": "hxd_mon_valve_1",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "HXD",
+        "creation": "Thu Feb 15 17:52:08 2018",
+        "device_class": "pcdsdevices.device_types.GateValve",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Feb 15 18:25:23 2018",
+        "lightpath": true,
+        "macros": null,
+        "name": "hxd_mon_valve_1",
+        "parent": null,
+        "prefix": "HX3:MON:VGC:01",
+        "screen": null,
+        "stand": null,
+        "system": "vacuum",
+        "type": "pcdsdevices.happi.containers.GateValve",
+        "z": 782.5
+    },
+    "hxd_mon_valve_2": {
+        "_id": "hxd_mon_valve_2",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "HXD",
+        "creation": "Thu Feb 15 17:52:08 2018",
+        "device_class": "pcdsdevices.device_types.GateValve",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Feb 15 18:25:23 2018",
+        "lightpath": true,
+        "macros": null,
+        "name": "hxd_mon_valve_2",
+        "parent": null,
+        "prefix": "HX3:MON:VGC:02",
+        "screen": null,
+        "stand": null,
+        "system": "vacuum",
+        "type": "pcdsdevices.happi.containers.GateValve",
+        "z": 783.5
     },
     "icl_sds_sel_b": {
         "_id": "icl_sds_sel_b",
@@ -4484,6 +2156,694 @@
         "type": "pcdsdevices.happi.containers.LCLSItem",
         "z": 753.6
     },
+    "mec_attenuator": {
+        "_id": "mec_attenuator",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "MEC",
+        "creation": "Tue Feb 27 11:38:15 2018",
+        "device_class": "pcdsdevices.device_types.Attenuator",
+        "kwargs": {
+            "n_filters": "{{n_filters}}",
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Feb 27 11:38:15 2018",
+        "macros": null,
+        "n_filters": 10,
+        "name": "mec_attenuator",
+        "parent": null,
+        "prefix": "MEC:ATT",
+        "screen": null,
+        "stand": null,
+        "system": "beam control",
+        "type": "pcdsdevices.happi.containers.Attenuator",
+        "z": 981.2
+    },
+    "mec_bxl_valve": {
+        "_id": "mec_bxl_valve",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "MEC",
+        "creation": "Thu Feb 15 17:52:08 2018",
+        "device_class": "pcdsdevices.device_types.GateValve",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Feb 15 18:25:24 2018",
+        "macros": null,
+        "name": "mec_bxl_valve",
+        "parent": null,
+        "prefix": "MEC:BXL:VGC:01",
+        "screen": null,
+        "stand": null,
+        "system": "vacuum",
+        "type": "pcdsdevices.happi.containers.GateValve",
+        "z": 979.0
+    },
+    "mec_hxm_valve": {
+        "_id": "mec_hxm_valve",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "MEC",
+        "creation": "Thu Feb 15 17:52:08 2018",
+        "device_class": "pcdsdevices.device_types.GateValve",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Feb 15 18:25:24 2018",
+        "macros": null,
+        "name": "mec_hxm_valve",
+        "parent": null,
+        "prefix": "MEC:HXM:VGC:01",
+        "screen": null,
+        "stand": null,
+        "system": "vacuum",
+        "type": "pcdsdevices.happi.containers.GateValve",
+        "z": 990.5
+    },
+    "mec_ipm1": {
+        "_id": "mec_ipm1",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "MEC",
+        "creation": "Tue Feb 27 11:40:15 2018",
+        "data": null,
+        "device_class": "pcdsdevices.device_types.IPM",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Feb 27 11:40:15 2018",
+        "macros": null,
+        "name": "mec_ipm1",
+        "parent": null,
+        "prefix": "MEC:IPM1",
+        "screen": null,
+        "stand": null,
+        "system": "diagnostic",
+        "type": "pcdsdevices.happi.containers.IPM",
+        "z": 990.2
+    },
+    "mec_mxt_valve": {
+        "_id": "mec_mxt_valve",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "MEC",
+        "creation": "Thu Feb 15 17:52:08 2018",
+        "device_class": "pcdsdevices.device_types.GateValve",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Feb 15 18:25:24 2018",
+        "macros": null,
+        "name": "mec_mxt_valve",
+        "parent": null,
+        "prefix": "HXX:MXT:VGC:05",
+        "screen": null,
+        "stand": null,
+        "system": "vacuum",
+        "type": "pcdsdevices.happi.containers.GateValve",
+        "z": 870.96
+    },
+    "mec_pim1": {
+        "_id": "mec_pim1",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "MEC",
+        "creation": "Tue Feb 27 11:15:18 2018",
+        "device_class": "pcdsdevices.pim.PIM",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Feb 27 11:15:18 2018",
+        "macros": null,
+        "name": "mec_pim1",
+        "parent": null,
+        "prefix": "MEC:PIM1",
+        "screen": null,
+        "stand": null,
+        "system": null,
+        "type": "pcdsdevices.happi.containers.LCLSItem",
+        "z": 981.4
+    },
+    "mec_pulsepicker": {
+        "_id": "mec_pulsepicker",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "MEC",
+        "creation": "Tue Feb 27 11:31:29 2018",
+        "device_class": "pcdsdevices.device_types.PulsePicker",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Feb 27 11:31:29 2018",
+        "macros": null,
+        "name": "mec_pulsepicker",
+        "parent": null,
+        "prefix": "MEC:HXM:MMS:18",
+        "screen": null,
+        "stand": null,
+        "system": "beam control",
+        "type": "pcdsdevices.happi.containers.PulsePicker",
+        "z": 981.01
+    },
+    "mec_yag0": {
+        "_id": "mec_yag0",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "HXD",
+        "creation": "Tue Feb 27 11:15:18 2018",
+        "device_class": "pcdsdevices.pim.PIMWithFocus",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Feb 27 11:15:18 2018",
+        "lightpath": true,
+        "macros": null,
+        "name": "mec_yag0",
+        "parent": null,
+        "prefix": "HXX:HXM:PIM",
+        "screen": null,
+        "stand": null,
+        "system": null,
+        "type": "pcdsdevices.happi.containers.LCLSItem",
+        "z": 818.416
+    },
+    "mfx_attenuator": {
+        "_id": "mfx_attenuator",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "MFX",
+        "creation": "Mon Jan 29 13:49:27 2018",
+        "device_class": "pcdsdevices.device_types.Attenuator",
+        "kwargs": {
+            "n_filters": "{{n_filters}}",
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Feb 27 10:21:22 2018",
+        "macros": null,
+        "n_filters": 10,
+        "name": "mfx_attenuator",
+        "parent": null,
+        "prefix": "MFX:ATT",
+        "screen": null,
+        "stand": "DIA",
+        "system": "beam control",
+        "type": "pcdsdevices.happi.containers.Attenuator",
+        "z": 984.4
+    },
+    "mfx_dg1_ipm": {
+        "_id": "mfx_dg1_ipm",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "MFX",
+        "creation": "Tue Mar 26 10:49:16 2019",
+        "detailed_screen": null,
+        "device_class": "pcdsdevices.device_types.IPM",
+        "documentation": null,
+        "embedded_screen": null,
+        "engineering_screen": null,
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Wed Mar 27 09:56:09 2019",
+        "lightpath": false,
+        "macros": null,
+        "name": "mfx_dg1_ipm",
+        "parent": null,
+        "prefix": "MFX:DG1:IPM",
+        "stand": "DG1",
+        "system": "diagnostic",
+        "type": "pcdsdevices.happi.containers.IPM",
+        "z": 1019.59
+    },
+    "mfx_dg1_pim": {
+        "_id": "mfx_dg1_pim",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "MFX",
+        "creation": "Mon Jan 29 14:04:28 2018",
+        "data": null,
+        "device_class": "pcdsdevices.pim.PIMWithLED",
+        "kwargs": {
+            "name": "{{name}}",
+            "prefix_det": "{{prefix_det}}"
+        },
+        "last_edit": "Tue Feb 27 10:21:22 2018",
+        "macros": null,
+        "name": "mfx_dg1_pim",
+        "parent": null,
+        "prefix": "MFX:DG1:PIM",
+        "prefix_det": "MFX:DG1:P6740",
+        "screen": null,
+        "stand": "DG1",
+        "system": "diagnostic",
+        "type": "pcdsdevices.happi.containers.PIM",
+        "z": 1019.79
+    },
+    "mfx_dg1_slits": {
+        "_id": "mfx_dg1_slits",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "MFX",
+        "creation": "Mon Jan 29 10:50:42 2018",
+        "device_class": "pcdsdevices.device_types.Slits",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Feb 27 10:21:22 2018",
+        "macros": null,
+        "name": "mfx_dg1_slits",
+        "parent": null,
+        "prefix": "MFX:DG1:JAWS",
+        "screen": null,
+        "stand": "DG1",
+        "system": "beam control",
+        "type": "pcdsdevices.happi.containers.Slits",
+        "z": 1019.3
+    },
+    "mfx_dg1_valve_1": {
+        "_id": "mfx_dg1_valve_1",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "MFX",
+        "creation": "Tue Feb 27 10:25:17 2018",
+        "device_class": "pcdsdevices.device_types.GateValve",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Feb 27 10:26:30 2018",
+        "macros": null,
+        "name": "mfx_dg1_valve_1",
+        "parent": null,
+        "prefix": "MFX:DG1:VGC:01",
+        "screen": null,
+        "stand": "DG1",
+        "system": "vacuum",
+        "type": "pcdsdevices.happi.containers.GateValve",
+        "z": 1018.54
+    },
+    "mfx_dg1_valve_2": {
+        "_id": "mfx_dg1_valve_2",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "MFX",
+        "creation": "Tue Feb 27 10:26:03 2018",
+        "device_class": "pcdsdevices.device_types.GateValve",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Feb 27 10:26:03 2018",
+        "macros": null,
+        "name": "mfx_dg1_valve_2",
+        "parent": null,
+        "prefix": "MFX:DG1:VGC:02",
+        "screen": null,
+        "stand": "DG1",
+        "system": "vacuum",
+        "type": "pcdsdevices.happi.containers.GateValve",
+        "z": 1019.99
+    },
+    "mfx_dg1_wave8_motor": {
+        "_id": "mfx_dg1_wave8_motor",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "MFX",
+        "creation": "Fri Sep 14 14:21:35 2018",
+        "device_class": "pcdsdevices.device_types.IMS",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Fri Sep 14 14:21:35 2018",
+        "macros": null,
+        "name": "mfx_dg1_wave8_motor",
+        "parent": null,
+        "prefix": "MFX:DG1:MMS:08",
+        "screen": null,
+        "stand": "DG1",
+        "system": null,
+        "type": "pcdsdevices.happi.containers.LCLSItem",
+        "z": -1.0
+    },
+    "mfx_dg2_downstream_slits": {
+        "_id": "mfx_dg2_downstream_slits",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "MFX",
+        "creation": "Mon Jan 29 14:33:08 2018",
+        "device_class": "pcdsdevices.device_types.Slits",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Feb 27 10:21:22 2018",
+        "macros": null,
+        "name": "mfx_dg2_downstream_slits",
+        "parent": null,
+        "prefix": "MFX:DG2:JAWS:DS",
+        "screen": null,
+        "stand": "DG2",
+        "system": "beam control",
+        "type": "pcdsdevices.happi.containers.Slits",
+        "z": 1022.99
+    },
+    "mfx_dg2_ipm": {
+        "_id": "mfx_dg2_ipm",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "MFX",
+        "creation": "Wed Mar 27 09:53:48 2019",
+        "data": null,
+        "detailed_screen": null,
+        "device_class": "pcdsdevices.device_types.IPM",
+        "documentation": null,
+        "embedded_screen": null,
+        "engineering_screen": null,
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Wed Mar 27 09:53:48 2019",
+        "lightpath": false,
+        "macros": null,
+        "name": "mfx_dg2_ipm",
+        "parent": null,
+        "prefix": "MFX:DG2:IPM",
+        "stand": "DG2",
+        "system": "diagnostic",
+        "type": "pcdsdevices.happi.containers.IPM",
+        "z": 1021.54
+    },
+    "mfx_dg2_midstream_slits": {
+        "_id": "mfx_dg2_midstream_slits",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "MFX",
+        "creation": "Mon Jan 29 14:32:42 2018",
+        "device_class": "pcdsdevices.device_types.Slits",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Feb 27 10:21:22 2018",
+        "macros": null,
+        "name": "mfx_dg2_midstream_slits",
+        "parent": null,
+        "prefix": "MFX:DG2:JAWS:MS",
+        "screen": null,
+        "stand": "DG2",
+        "system": "beam control",
+        "type": "pcdsdevices.happi.containers.Slits",
+        "z": 1022.84
+    },
+    "mfx_dg2_pim": {
+        "_id": "mfx_dg2_pim",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "MFX",
+        "creation": "Mon Jan 29 14:25:39 2018",
+        "data": null,
+        "device_class": "pcdsdevices.pim.PIMWithBoth",
+        "kwargs": {
+            "name": "{{name}}",
+            "prefix_det": "{{prefix_det}}"
+        },
+        "last_edit": "Tue Feb 27 10:21:22 2018",
+        "macros": null,
+        "name": "mfx_dg2_pim",
+        "parent": null,
+        "prefix": "MFX:DG2:PIM",
+        "prefix_det": "MFX:DG2:P6740",
+        "screen": null,
+        "stand": "DG2",
+        "system": "diagnostic",
+        "type": "pcdsdevices.happi.containers.PIM",
+        "z": 1021.74
+    },
+    "mfx_dg2_upstream_slits": {
+        "_id": "mfx_dg2_upstream_slits",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "MFX",
+        "creation": "Mon Jan 29 14:32:11 2018",
+        "device_class": "pcdsdevices.device_types.Slits",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Feb 27 10:21:22 2018",
+        "macros": null,
+        "name": "mfx_dg2_upstream_slits",
+        "parent": null,
+        "prefix": "MFX:DG2:JAWS:US",
+        "screen": null,
+        "stand": "DG2",
+        "system": "beam control",
+        "type": "pcdsdevices.happi.containers.Slits",
+        "z": 1021.29
+    },
+    "mfx_dia_ipm": {
+        "_id": "mfx_dia_ipm",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "MFX",
+        "creation": "Mon Jan 29 14:38:42 2018",
+        "data": null,
+        "detailed_screen": null,
+        "device_class": "pcdsdevices.device_types.IPM",
+        "documentation": null,
+        "embedded_screen": null,
+        "engineering_screen": null,
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue May  7 15:55:30 2019",
+        "lightpath": false,
+        "macros": null,
+        "name": "mfx_dia_ipm",
+        "parent": null,
+        "prefix": "MFX:DIA:IPM",
+        "screen": null,
+        "stand": "DIA",
+        "system": "diagnostic",
+        "type": "pcdsdevices.happi.containers.IPM",
+        "z": 984.85
+    },
+    "mfx_dia_pim": {
+        "_id": "mfx_dia_pim",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "MFX",
+        "creation": "Mon Jan 29 14:02:41 2018",
+        "data": null,
+        "detailed_screen": null,
+        "device_class": "pcdsdevices.pim.PIMWithFocus",
+        "documentation": null,
+        "embedded_screen": null,
+        "engineering_screen": null,
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue May  7 09:56:26 2019",
+        "lightpath": false,
+        "macros": null,
+        "name": "mfx_dia_pim",
+        "parent": null,
+        "prefix": "MFX:DIA:PIM",
+        "prefix_det": "MFX:DIA:CVV:01",
+        "screen": null,
+        "stand": "DIA",
+        "system": "diagnostic",
+        "type": "pcdsdevices.happi.containers.PIM",
+        "z": 984.9
+    },
+    "mfx_dia_valve_01": {
+        "_id": "mfx_dia_valve_01",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "MFX",
+        "creation": "Thu Feb 15 17:52:08 2018",
+        "device_class": "pcdsdevices.device_types.GateValve",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Wed May 16 14:23:19 2018",
+        "macros": null,
+        "name": "mfx_dia_valve_01",
+        "parent": null,
+        "prefix": "MFX:DIA:VGC:01",
+        "screen": null,
+        "stand": "DIA",
+        "system": "vacuum",
+        "type": "pcdsdevices.happi.containers.GateValve",
+        "z": 983.0
+    },
+    "mfx_dia_valve_02": {
+        "_id": "mfx_dia_valve_02",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "MFX",
+        "creation": "Thu Feb 15 17:52:08 2018",
+        "detailed_screen": null,
+        "device_class": "pcdsdevices.device_types.GateValve",
+        "documentation": null,
+        "embedded_screen": null,
+        "engineering_screen": null,
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Mar 26 10:11:33 2019",
+        "lightpath": false,
+        "macros": null,
+        "name": "mfx_dia_valve_02",
+        "parent": null,
+        "prefix": "MFX:DIA:VGC:02",
+        "screen": null,
+        "stand": null,
+        "system": "vacuum",
+        "type": "pcdsdevices.happi.containers.GateValve",
+        "z": 990.1
+    },
+    "mfx_dvd_valve": {
+        "_id": "mfx_dvd_valve",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "MFX",
+        "creation": "Thu Feb 15 17:52:08 2018",
+        "device_class": "pcdsdevices.device_types.GateValve",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Feb 15 18:25:24 2018",
+        "macros": null,
+        "name": "mfx_dvd_valve",
+        "parent": null,
+        "prefix": "MFX:DVD:VGC:01",
+        "screen": null,
+        "stand": null,
+        "system": "vacuum",
+        "type": "pcdsdevices.happi.containers.GateValve",
+        "z": 945.9630000000001
+    },
+    "mfx_mxt_valve": {
+        "_id": "mfx_mxt_valve",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "MFX",
+        "creation": "Thu Feb 15 17:52:08 2018",
+        "device_class": "pcdsdevices.device_types.GateValve",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Feb 15 18:25:23 2018",
+        "macros": null,
+        "name": "mfx_mxt_valve",
+        "parent": null,
+        "prefix": "HXX:MXT:VGC:04",
+        "screen": null,
+        "stand": null,
+        "system": "vacuum",
+        "type": "pcdsdevices.happi.containers.GateValve",
+        "z": 870.96
+    },
+    "mfx_pulsepicker": {
+        "_id": "mfx_pulsepicker",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "MFX",
+        "creation": "Mon Jan 29 13:47:39 2018",
+        "device_class": "pcdsdevices.device_types.PulsePicker",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Feb 27 16:59:49 2018",
+        "macros": null,
+        "name": "mfx_pulsepicker",
+        "parent": null,
+        "prefix": "MFX:DIA:MMS:07",
+        "screen": null,
+        "stand": "DIA",
+        "system": "beam control",
+        "type": "pcdsdevices.happi.containers.PulsePicker",
+        "z": 984.2
+    },
+    "mfx_reflaser": {
+        "_id": "mfx_reflaser",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "MFX",
+        "creation": "Mon Jan 29 13:53:19 2018",
+        "detailed_screen": null,
+        "device_class": "pcdsdevices.inout.InOutRecordPositioner",
+        "documentation": null,
+        "embedded_screen": null,
+        "engineering_screen": null,
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue May  7 09:41:46 2019",
+        "lightpath": false,
+        "macros": null,
+        "name": "mfx_reflaser",
+        "parent": null,
+        "prefix": "MFX:DG1:RLM:MIRROR",
+        "screen": null,
+        "stand": "DG1",
+        "system": null,
+        "type": "pcdsdevices.happi.containers.LCLSItem",
+        "z": 1018.82
+    },
     "mr1k2_switch": {
         "_id": "mr1k2_switch",
         "active": true,
@@ -4677,6 +3037,54 @@
         "type": "pcdsdevices.happi.containers.LCLSItem",
         "z": 748.0869
     },
+    "mxt_valve_1": {
+        "_id": "mxt_valve_1",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "HXD",
+        "creation": "Thu Feb 15 17:52:08 2018",
+        "device_class": "pcdsdevices.device_types.GateValve",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Feb 15 18:25:23 2018",
+        "lightpath": true,
+        "macros": null,
+        "name": "mxt_valve_1",
+        "parent": null,
+        "prefix": "HXX:MXT:VGC:01",
+        "screen": null,
+        "stand": null,
+        "system": "vacuum",
+        "type": "pcdsdevices.happi.containers.GateValve",
+        "z": 812.8689999999999
+    },
+    "mxt_valve_2": {
+        "_id": "mxt_valve_2",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "HXD",
+        "creation": "Thu Feb 15 17:52:08 2018",
+        "device_class": "pcdsdevices.device_types.GateValve",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Feb 15 18:25:23 2018",
+        "lightpath": true,
+        "macros": null,
+        "name": "mxt_valve_2",
+        "parent": null,
+        "prefix": "HXX:MXT:VGC:02",
+        "screen": null,
+        "stand": null,
+        "system": "vacuum",
+        "type": "pcdsdevices.happi.containers.GateValve",
+        "z": 818.2
+    },
     "pa1l0_vfs_01": {
         "_id": "pa1l0_vfs_01",
         "active": false,
@@ -4745,6 +3153,146 @@
         "stand": null,
         "type": "pcdsdevices.happi.containers.LCLSItem",
         "z": 695.0
+    },
+    "sh1": {
+        "_id": "sh1",
+        "active": false,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "HXD",
+        "creation": "Tue Feb 27 10:46:53 2018",
+        "device_class": "pcdsdevices.valve.PPSStopper",
+        "kwargs": {
+            "name": "{{name}}",
+            "out_state": "NOT_IN"
+        },
+        "last_edit": "Tue Feb 27 10:47:44 2018",
+        "macros": null,
+        "name": "sh1",
+        "parent": null,
+        "prefix": "PPS:NEH1:1:SH1INSUM",
+        "screen": null,
+        "stand": null,
+        "system": null,
+        "type": "pcdsdevices.happi.containers.LCLSItem",
+        "z": 755.421
+    },
+    "sh2": {
+        "_id": "sh2",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "HXD",
+        "creation": "Tue Feb 27 10:46:53 2018",
+        "device_class": "pcdsdevices.valve.PPSStopper",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Feb 27 10:46:53 2018",
+        "lightpath": true,
+        "macros": null,
+        "name": "sh2",
+        "parent": null,
+        "prefix": "STPR:XRT1:1:SH2_PPSSUM",
+        "screen": null,
+        "stand": null,
+        "system": null,
+        "type": "pcdsdevices.happi.containers.LCLSItem",
+        "z": 803.1
+    },
+    "sh4": {
+        "_id": "sh4",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "XCS",
+        "creation": "Tue Feb 27 10:46:52 2018",
+        "device_class": "pcdsdevices.valve.PPSStopper",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Feb 27 10:46:52 2018",
+        "macros": null,
+        "name": "sh4",
+        "parent": null,
+        "prefix": "PPS:FEH1:4:S4STPRSUM",
+        "screen": null,
+        "stand": null,
+        "system": null,
+        "type": "pcdsdevices.happi.containers.LCLSItem",
+        "z": 1000.5
+    },
+    "sh45": {
+        "_id": "sh45",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "MFX",
+        "creation": "Mon Jan 29 13:59:33 2018",
+        "device_class": "pcdsdevices.valve.PPSStopper",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Feb 27 10:21:22 2018",
+        "macros": null,
+        "name": "sh45",
+        "parent": null,
+        "prefix": "PPS:FEH1:45:S45STPRSUM",
+        "screen": null,
+        "stand": null,
+        "system": null,
+        "type": "pcdsdevices.happi.containers.LCLSItem",
+        "z": 952.2
+    },
+    "sh5": {
+        "_id": "sh5",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "CXI",
+        "creation": "Tue Feb 27 10:46:52 2018",
+        "device_class": "pcdsdevices.valve.PPSStopper",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Feb 27 10:46:52 2018",
+        "macros": null,
+        "name": "sh5",
+        "parent": null,
+        "prefix": "PPS:FEH1:5:S5STPRSUM",
+        "screen": null,
+        "stand": null,
+        "system": null,
+        "type": "pcdsdevices.happi.containers.LCLSItem",
+        "z": 979.0
+    },
+    "sh6": {
+        "_id": "sh6",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "MEC",
+        "creation": "Tue Feb 27 10:46:53 2018",
+        "device_class": "pcdsdevices.valve.PPSStopper",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Feb 27 10:46:53 2018",
+        "macros": null,
+        "name": "sh6",
+        "parent": null,
+        "prefix": "PPS:FEH1:6:S6STPRSUM",
+        "screen": null,
+        "stand": null,
+        "system": null,
+        "type": "pcdsdevices.happi.containers.LCLSItem",
+        "z": 987.1
     },
     "sl1l0": {
         "_id": "sl1l0",
@@ -5041,6 +3589,156 @@
         "type": "pcdsdevices.happi.containers.LCLSItem",
         "z": 779.4857
     },
+    "um6_ipm": {
+        "_id": "um6_ipm",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "HXD",
+        "creation": "Tue Feb 27 11:40:15 2018",
+        "data": null,
+        "device_class": "pcdsdevices.device_types.IPM",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Feb 27 11:40:15 2018",
+        "lightpath": true,
+        "macros": null,
+        "name": "um6_ipm",
+        "parent": null,
+        "prefix": "HXX:UM6:IPM",
+        "screen": null,
+        "stand": null,
+        "system": "diagnostic",
+        "type": "pcdsdevices.happi.containers.IPM",
+        "z": 810.332
+    },
+    "um6_pim": {
+        "_id": "um6_pim",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "HXD",
+        "creation": "Tue Feb 27 11:15:18 2018",
+        "device_class": "pcdsdevices.pim.PIMWithLED",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Feb 27 11:15:18 2018",
+        "lightpath": true,
+        "macros": null,
+        "name": "um6_pim",
+        "parent": null,
+        "prefix": "HXX:UM6:PIM",
+        "screen": null,
+        "stand": null,
+        "system": null,
+        "type": "pcdsdevices.happi.containers.LCLSItem",
+        "z": 810.135
+    },
+    "um6_slits": {
+        "_id": "um6_slits",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "HXD",
+        "creation": "Tue Feb 27 10:41:25 2018",
+        "device_class": "pcdsdevices.device_types.Slits",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Feb 27 10:41:25 2018",
+        "lightpath": true,
+        "macros": null,
+        "name": "um6_slits",
+        "parent": null,
+        "prefix": "HXX:UM6:JAWS",
+        "screen": null,
+        "stand": null,
+        "system": "beam control",
+        "type": "pcdsdevices.happi.containers.Slits",
+        "z": 809.966
+    },
+    "um6_stopper": {
+        "_id": "um6_stopper",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "HXD",
+        "creation": "Tue Feb 27 11:46:45 2018",
+        "device_class": "pcdsdevices.device_types.Stopper",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Feb 27 15:08:45 2018",
+        "lightpath": true,
+        "macros": null,
+        "name": "um6_stopper",
+        "parent": null,
+        "prefix": "HXX:UM6:STP:01",
+        "screen": null,
+        "stand": null,
+        "system": null,
+        "type": "pcdsdevices.happi.containers.Stopper",
+        "z": 811.035
+    },
+    "uvd_valve": {
+        "_id": "uvd_valve",
+        "active": false,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "HXD",
+        "creation": "Thu Feb 15 17:52:08 2018",
+        "device_class": "pcdsdevices.device_types.GateValve",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Feb 15 18:25:23 2018",
+        "macros": null,
+        "name": "uvd_valve",
+        "parent": null,
+        "prefix": "HX2:UVD:VGC:01",
+        "screen": null,
+        "stand": null,
+        "system": "vacuum",
+        "type": "pcdsdevices.happi.containers.GateValve",
+        "z": 769.0
+    },
+    "xcs_attenuator": {
+        "_id": "xcs_attenuator",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "XCS",
+        "creation": "Tue Feb 27 11:38:15 2018",
+        "detailed_screen": null,
+        "device_class": "pcdsdevices.device_types.Attenuator",
+        "documentation": null,
+        "embedded_screen": null,
+        "engineering_screen": null,
+        "kwargs": {
+            "n_filters": "{{n_filters}}",
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue May  7 16:24:57 2019",
+        "lightpath": false,
+        "macros": null,
+        "n_filters": 10,
+        "name": "xcs_attenuator",
+        "parent": null,
+        "prefix": "XCS:ATT",
+        "screen": null,
+        "stand": null,
+        "system": "beam control",
+        "type": "pcdsdevices.happi.containers.Attenuator",
+        "z": 1002.326
+    },
     "xcs_ccm": {
         "_id": "xcs_ccm",
         "active": true,
@@ -5073,6 +3771,690 @@
         "type": "pcdsdevices.happi.containers.LCLSItem",
         "z": 999999.0
     },
+    "xcs_dg3_ipm": {
+        "_id": "xcs_dg3_ipm",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "XCS",
+        "creation": "Tue Feb 27 11:40:15 2018",
+        "data": null,
+        "detailed_screen": null,
+        "device_class": "pcdsdevices.device_types.IPM",
+        "documentation": null,
+        "embedded_screen": null,
+        "engineering_screen": null,
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue May  7 15:44:25 2019",
+        "lightpath": false,
+        "macros": null,
+        "name": "xcs_dg3_ipm",
+        "parent": null,
+        "prefix": "XCS:DG3:IPM",
+        "screen": null,
+        "stand": null,
+        "system": "diagnostic",
+        "type": "pcdsdevices.happi.containers.IPM",
+        "z": 979.0
+    },
+    "xcs_dg3_pim": {
+        "_id": "xcs_dg3_pim",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "XCS",
+        "creation": "Tue Feb 27 11:15:19 2018",
+        "detailed_screen": null,
+        "device_class": "pcdsdevices.pim.PIMWithLED",
+        "documentation": null,
+        "embedded_screen": null,
+        "engineering_screen": null,
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue May  7 15:43:49 2019",
+        "lightpath": false,
+        "macros": null,
+        "name": "xcs_dg3_pim",
+        "parent": null,
+        "prefix": "XCS:DG3:PIM",
+        "screen": null,
+        "stand": null,
+        "system": null,
+        "type": "pcdsdevices.happi.containers.LCLSItem",
+        "z": 979.2
+    },
+    "xcs_dg3_slits": {
+        "_id": "xcs_dg3_slits",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "XCS",
+        "creation": "Tue Feb 27 10:41:25 2018",
+        "device_class": "pcdsdevices.device_types.Slits",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Feb 27 10:41:25 2018",
+        "macros": null,
+        "name": "xcs_dg3_slits",
+        "parent": null,
+        "prefix": "XCS:DG3:JAWS",
+        "screen": null,
+        "stand": null,
+        "system": "beam control",
+        "type": "pcdsdevices.happi.containers.Slits",
+        "z": 978.813
+    },
+    "xcs_dg3_valve_2": {
+        "_id": "xcs_dg3_valve_2",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "XCS",
+        "creation": "Thu Feb 15 18:21:13 2018",
+        "device_class": "pcdsdevices.device_types.GateValve",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Feb 15 18:25:24 2018",
+        "macros": null,
+        "name": "xcs_dg3_valve_2",
+        "parent": null,
+        "prefix": "XCS:DG3:VGC:02",
+        "screen": null,
+        "stand": null,
+        "system": "vacuum",
+        "type": "pcdsdevices.happi.containers.GateValve",
+        "z": 990.913
+    },
+    "xcs_lam_valve_1": {
+        "_id": "xcs_lam_valve_1",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "XCS",
+        "creation": "Thu Feb 15 18:21:13 2018",
+        "device_class": "pcdsdevices.device_types.GateValve",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Feb 15 18:25:24 2018",
+        "macros": null,
+        "name": "xcs_lam_valve_1",
+        "parent": null,
+        "prefix": "XCS:LAM:VGC:01",
+        "screen": null,
+        "stand": null,
+        "system": "vacuum",
+        "type": "pcdsdevices.happi.containers.GateValve",
+        "z": 1008.0
+    },
+    "xcs_lam_valve_2": {
+        "_id": "xcs_lam_valve_2",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "XCS",
+        "creation": "Thu Feb 15 18:21:13 2018",
+        "device_class": "pcdsdevices.device_types.GateValve",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Feb 15 18:25:24 2018",
+        "macros": null,
+        "name": "xcs_lam_valve_2",
+        "parent": null,
+        "prefix": "XCS:LAM:VGC:02",
+        "screen": null,
+        "stand": null,
+        "system": "vacuum",
+        "type": "pcdsdevices.happi.containers.GateValve",
+        "z": 1009.0
+    },
+    "xcs_lodcm": {
+        "_id": "xcs_lodcm",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "HXD",
+        "creation": "Tue Feb 27 12:53:14 2018",
+        "device_class": "pcdsdevices.device_types.LODCM",
+        "kwargs": {
+            "main_line": "{{beamline}}",
+            "mono_line": "{{mono_line}}",
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Feb 27 12:53:14 2018",
+        "lightpath": true,
+        "macros": null,
+        "mono_line": "XCS",
+        "name": "xcs_lodcm",
+        "parent": null,
+        "prefix": "XCS:LODCM",
+        "screen": null,
+        "stand": null,
+        "system": "beam control",
+        "type": "pcdsdevices.happi.containers.LODCM",
+        "z": 964.76
+    },
+    "xcs_mon_ipm": {
+        "_id": "xcs_mon_ipm",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "XCS",
+        "creation": "Tue Feb 27 11:40:15 2018",
+        "data": null,
+        "device_class": "pcdsdevices.device_types.IPM",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Feb 27 11:40:15 2018",
+        "macros": null,
+        "name": "xcs_mon_ipm",
+        "parent": null,
+        "prefix": "XCS:MON:IPM",
+        "screen": null,
+        "stand": null,
+        "system": "diagnostic",
+        "type": "pcdsdevices.happi.containers.IPM",
+        "z": 971.0
+    },
+    "xcs_pbt_pim": {
+        "_id": "xcs_pbt_pim",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "PBT",
+        "creation": "Tue Feb 27 11:15:19 2018",
+        "detailed_screen": null,
+        "device_class": "pcdsdevices.pim.PIMWithFocus",
+        "documentation": null,
+        "embedded_screen": null,
+        "engineering_screen": null,
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue May  7 15:47:17 2019",
+        "lightpath": false,
+        "macros": null,
+        "name": "xcs_pbt_pim",
+        "parent": null,
+        "prefix": "XCS:PBT:PIM",
+        "screen": null,
+        "stand": null,
+        "system": null,
+        "type": "pcdsdevices.happi.containers.LCLSItem",
+        "z": 930.6
+    },
+    "xcs_pbt_valve_1": {
+        "_id": "xcs_pbt_valve_1",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "PBT",
+        "creation": "Thu Feb 15 18:21:13 2018",
+        "device_class": "pcdsdevices.device_types.GateValve",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Feb 15 18:25:24 2018",
+        "macros": null,
+        "name": "xcs_pbt_valve_1",
+        "parent": null,
+        "prefix": "XCS:PBT:VGC:01",
+        "screen": null,
+        "stand": null,
+        "system": "vacuum",
+        "type": "pcdsdevices.happi.containers.GateValve",
+        "z": 870.96
+    },
+    "xcs_pbt_valve_2": {
+        "_id": "xcs_pbt_valve_2",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "PBT",
+        "creation": "Thu Feb 15 18:21:13 2018",
+        "device_class": "pcdsdevices.device_types.GateValve",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Feb 15 18:25:24 2018",
+        "macros": null,
+        "name": "xcs_pbt_valve_2",
+        "parent": null,
+        "prefix": "XCS:PBT:VGC:02",
+        "screen": null,
+        "stand": null,
+        "system": "vacuum",
+        "type": "pcdsdevices.happi.containers.GateValve",
+        "z": 925.9
+    },
+    "xcs_pbt_valve_3": {
+        "_id": "xcs_pbt_valve_3",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "PBT",
+        "creation": "Thu Feb 15 18:21:13 2018",
+        "device_class": "pcdsdevices.device_types.GateValve",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Feb 15 18:25:24 2018",
+        "macros": null,
+        "name": "xcs_pbt_valve_3",
+        "parent": null,
+        "prefix": "XCS:PBT:VGC:03",
+        "screen": null,
+        "stand": null,
+        "system": "vacuum",
+        "type": "pcdsdevices.happi.containers.GateValve",
+        "z": 930.4
+    },
+    "xcs_pbt_valve_4": {
+        "_id": "xcs_pbt_valve_4",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "PBT",
+        "creation": "Thu Feb 15 18:21:13 2018",
+        "device_class": "pcdsdevices.device_types.GateValve",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Feb 15 18:25:24 2018",
+        "macros": null,
+        "name": "xcs_pbt_valve_4",
+        "parent": null,
+        "prefix": "XCS:PBT:VGC:04",
+        "screen": null,
+        "stand": null,
+        "system": "vacuum",
+        "type": "pcdsdevices.happi.containers.GateValve",
+        "z": 961.3
+    },
+    "xcs_pulsepicker": {
+        "_id": "xcs_pulsepicker",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "XCS",
+        "creation": "Tue Feb 27 11:31:29 2018",
+        "device_class": "pcdsdevices.device_types.PulsePicker",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Feb 27 11:31:29 2018",
+        "macros": null,
+        "name": "xcs_pulsepicker",
+        "parent": null,
+        "prefix": "XCS:SB2:MMS:09",
+        "screen": null,
+        "stand": null,
+        "system": "beam control",
+        "type": "pcdsdevices.happi.containers.PulsePicker",
+        "z": 1002.0
+    },
+    "xcs_reference_laser": {
+        "_id": "xcs_reference_laser",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "HXD",
+        "creation": "Tue Feb 27 11:51:31 2018",
+        "device_class": "pcdsdevices.inout.InOutRecordPositioner",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Feb 27 15:05:53 2018",
+        "lightpath": true,
+        "macros": null,
+        "name": "xcs_reference_laser",
+        "parent": null,
+        "prefix": "XCS:REFLASER1:MIRROR",
+        "screen": null,
+        "stand": null,
+        "system": null,
+        "type": "pcdsdevices.happi.containers.Stopper",
+        "z": 958.497
+    },
+    "xcs_sb1_ipm": {
+        "_id": "xcs_sb1_ipm",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "XCS",
+        "creation": "Tue Feb 27 11:40:15 2018",
+        "data": null,
+        "detailed_screen": null,
+        "device_class": "pcdsdevices.device_types.IPM",
+        "documentation": null,
+        "embedded_screen": null,
+        "engineering_screen": null,
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue May  7 15:36:21 2019",
+        "lightpath": false,
+        "macros": null,
+        "name": "xcs_sb1_ipm",
+        "parent": null,
+        "prefix": "XCS:SB1:IPM",
+        "screen": null,
+        "stand": null,
+        "system": "diagnostic",
+        "type": "pcdsdevices.happi.containers.IPM",
+        "z": 1005.49
+    },
+    "xcs_sb1_pim": {
+        "_id": "xcs_sb1_pim",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "XCS",
+        "creation": "Tue Feb 27 11:15:19 2018",
+        "detailed_screen": null,
+        "device_class": "pcdsdevices.pim.PIMWithLED",
+        "documentation": null,
+        "embedded_screen": null,
+        "engineering_screen": null,
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue May  7 15:37:45 2019",
+        "lightpath": false,
+        "macros": null,
+        "name": "xcs_sb1_pim",
+        "parent": null,
+        "prefix": "XCS:SB1:PIM",
+        "screen": null,
+        "stand": null,
+        "system": null,
+        "type": "pcdsdevices.happi.containers.LCLSItem",
+        "z": 996.4
+    },
+    "xcs_sb1_slits": {
+        "_id": "xcs_sb1_slits",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "XCS",
+        "creation": "Tue Feb 27 10:41:25 2018",
+        "device_class": "pcdsdevices.device_types.Slits",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Feb 27 10:41:25 2018",
+        "macros": null,
+        "name": "xcs_sb1_slits",
+        "parent": null,
+        "prefix": "XCS:SB1:JAWS",
+        "screen": null,
+        "stand": null,
+        "system": "beam control",
+        "type": "pcdsdevices.happi.containers.Slits",
+        "z": 996.0
+    },
+    "xcs_sb1_stopper": {
+        "_id": "xcs_sb1_stopper",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "XCS",
+        "creation": "Tue Feb 27 11:46:45 2018",
+        "device_class": "pcdsdevices.device_types.Stopper",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Feb 27 15:05:26 2018",
+        "macros": null,
+        "name": "xcs_sb1_stopper",
+        "parent": null,
+        "prefix": "XCS:SB1:STP:01",
+        "screen": null,
+        "stand": null,
+        "system": null,
+        "type": "pcdsdevices.happi.containers.Stopper",
+        "z": 995.6
+    },
+    "xcs_sb1_valve": {
+        "_id": "xcs_sb1_valve",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "XCS",
+        "creation": "Thu Feb 15 18:21:13 2018",
+        "device_class": "pcdsdevices.device_types.GateValve",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Feb 15 18:25:24 2018",
+        "macros": null,
+        "name": "xcs_sb1_valve",
+        "parent": null,
+        "prefix": "XCS:SB1:VGC:01",
+        "screen": null,
+        "stand": null,
+        "system": "vacuum",
+        "type": "pcdsdevices.happi.containers.GateValve",
+        "z": 1000.2
+    },
+    "xcs_sb2_downstream_slits": {
+        "_id": "xcs_sb2_downstream_slits",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "XCS",
+        "creation": "Tue Feb 27 10:41:25 2018",
+        "detailed_screen": null,
+        "device_class": "pcdsdevices.device_types.Slits",
+        "documentation": null,
+        "embedded_screen": null,
+        "engineering_screen": null,
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue May  7 15:41:05 2019",
+        "lightpath": false,
+        "macros": null,
+        "name": "xcs_sb2_downstream_slits",
+        "parent": null,
+        "prefix": "XCS:SB2:DS:JAWS",
+        "screen": null,
+        "stand": null,
+        "system": "beam control",
+        "type": "pcdsdevices.happi.containers.Slits",
+        "z": 1005.29
+    },
+    "xcs_sb2_ipm": {
+        "_id": "xcs_sb2_ipm",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "XCS",
+        "creation": "Tue Feb 27 11:40:15 2018",
+        "data": null,
+        "detailed_screen": null,
+        "device_class": "pcdsdevices.device_types.IPM",
+        "documentation": null,
+        "embedded_screen": null,
+        "engineering_screen": null,
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue May  7 15:33:12 2019",
+        "lightpath": false,
+        "macros": null,
+        "name": "xcs_sb2_ipm",
+        "parent": null,
+        "prefix": "XCS:SB2:IPM",
+        "screen": null,
+        "stand": null,
+        "system": "diagnostic",
+        "type": "pcdsdevices.happi.containers.IPM",
+        "z": 1005.49
+    },
+    "xcs_sb2_pim": {
+        "_id": "xcs_sb2_pim",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "XCS",
+        "creation": "Tue Feb 27 11:15:19 2018",
+        "detailed_screen": null,
+        "device_class": "pcdsdevices.pim.PIMWithLED",
+        "documentation": null,
+        "embedded_screen": null,
+        "engineering_screen": null,
+        "kwargs": {
+            "name": "{{name}}",
+            "prefix_det": "{{prefix_det}}"
+        },
+        "last_edit": "Fri May 17 11:44:12 2019",
+        "lightpath": false,
+        "macros": null,
+        "name": "xcs_sb2_pim",
+        "parent": null,
+        "prefix": "XCS:SB2:PIM",
+        "prefix_det": "XCS:GIGE:04:",
+        "screen": null,
+        "stand": null,
+        "system": null,
+        "type": "pcdsdevices.happi.containers.LCLSItem",
+        "z": 1005.72
+    },
+    "xcs_sb2_upstream_slits": {
+        "_id": "xcs_sb2_upstream_slits",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "XCS",
+        "creation": "Tue Feb 27 10:41:25 2018",
+        "detailed_screen": null,
+        "device_class": "pcdsdevices.device_types.Slits",
+        "documentation": null,
+        "embedded_screen": null,
+        "engineering_screen": null,
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue May  7 15:41:32 2019",
+        "lightpath": false,
+        "macros": null,
+        "name": "xcs_sb2_upstream_slits",
+        "parent": null,
+        "prefix": "XCS:SB2:US:JAWS",
+        "screen": null,
+        "stand": null,
+        "system": "beam control",
+        "type": "pcdsdevices.happi.containers.Slits",
+        "z": 1005.11
+    },
+    "xcs_sb2_vgc_01": {
+        "_id": "xcs_sb2_vgc_01",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "XCS",
+        "creation": "Thu Feb 15 18:21:13 2018",
+        "device_class": "pcdsdevices.device_types.GateValve",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Feb 15 18:25:24 2018",
+        "macros": null,
+        "name": "xcs_sb2_vgc_01",
+        "parent": null,
+        "prefix": "XCS:SB2:VGC:01",
+        "screen": null,
+        "stand": null,
+        "system": "vacuum",
+        "type": "pcdsdevices.happi.containers.GateValve",
+        "z": 1002.0
+    },
+    "xcs_xfls": {
+        "_id": "xcs_xfls",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "XCS",
+        "creation": "Tue Feb 27 14:44:36 2018",
+        "device_class": "pcdsdevices.device_types.XFLS",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Feb 27 14:44:36 2018",
+        "macros": null,
+        "name": "xcs_xfls",
+        "parent": null,
+        "prefix": "XCS:XFLS",
+        "screen": null,
+        "stand": null,
+        "system": null,
+        "type": "pcdsdevices.happi.containers.LCLSItem",
+        "z": 1002.9780000000001
+    },
+    "xpp_attenuator": {
+        "_id": "xpp_attenuator",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "XPP",
+        "creation": "Tue Feb 27 11:38:16 2018",
+        "detailed_screen": null,
+        "device_class": "pcdsdevices.device_types.Attenuator",
+        "documentation": null,
+        "embedded_screen": null,
+        "engineering_screen": null,
+        "kwargs": {
+            "n_filters": "{{n_filters}}",
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue May  7 16:25:30 2019",
+        "lightpath": true,
+        "macros": null,
+        "n_filters": 10,
+        "name": "xpp_attenuator",
+        "parent": null,
+        "prefix": "XPP:ATT",
+        "screen": null,
+        "stand": null,
+        "system": "beam control",
+        "type": "pcdsdevices.happi.containers.Attenuator",
+        "z": 786.0
+    },
     "xpp_ccm": {
         "_id": "xpp_ccm",
         "active": true,
@@ -5104,5 +4486,623 @@
         "stand": null,
         "type": "pcdsdevices.happi.containers.LCLSItem",
         "z": 999999.0
+    },
+    "xpp_las_delay": {
+        "_id": "xpp_las_delay",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "XPP",
+        "creation": "Tue Jul 17 09:52:23 2018",
+        "device_class": "pcdsdevices.device_types.Newport",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Jul 17 16:03:33 2018",
+        "macros": null,
+        "name": "xpp_las_delay",
+        "parent": null,
+        "prefix": "XPP:LAS:MMN:04",
+        "screen": null,
+        "stand": null,
+        "system": null,
+        "type": "pcdsdevices.happi.containers.LCLSItem",
+        "z": -1.0
+    },
+    "xpp_las_lensf": {
+        "_id": "xpp_las_lensf",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "XPP",
+        "creation": "Tue Jul 17 12:32:43 2018",
+        "device_class": "pcdsdevices.device_types.Newport",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Jul 17 12:32:43 2018",
+        "macros": null,
+        "name": "xpp_las_lensf",
+        "parent": null,
+        "prefix": "XPP:LAS:MMN:08",
+        "screen": null,
+        "stand": null,
+        "system": null,
+        "type": "pcdsdevices.happi.containers.LCLSItem",
+        "z": -1.0
+    },
+    "xpp_las_lensh": {
+        "_id": "xpp_las_lensh",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "XPP",
+        "creation": "Tue Jul 17 11:14:47 2018",
+        "device_class": "pcdsdevices.device_types.Newport",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Jul 17 16:05:15 2018",
+        "macros": null,
+        "name": "xpp_las_lensh",
+        "parent": null,
+        "prefix": "XPP:LAS:MMN:06",
+        "screen": null,
+        "stand": null,
+        "system": null,
+        "type": "pcdsdevices.happi.containers.LCLSItem",
+        "z": -1.0
+    },
+    "xpp_las_lensv": {
+        "_id": "xpp_las_lensv",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "XPP",
+        "creation": "Tue Jul 17 10:39:07 2018",
+        "device_class": "pcdsdevices.device_types.Newport",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Jul 17 10:41:22 2018",
+        "macros": null,
+        "name": "xpp_las_lensv",
+        "parent": null,
+        "prefix": "XPP:LAS:MMN:05",
+        "screen": null,
+        "stand": null,
+        "system": null,
+        "type": "pcdsdevices.happi.containers.LCLSItem",
+        "z": -1.0
+    },
+    "xpp_las_tt_lensf": {
+        "_id": "xpp_las_tt_lensf",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "XPP",
+        "creation": "Tue Jul 17 12:38:51 2018",
+        "device_class": "pcdsdevices.device_types.Newport",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Jul 17 12:38:51 2018",
+        "macros": null,
+        "name": "xpp_las_tt_lensf",
+        "parent": null,
+        "prefix": "XPP:LAS:MMN:15",
+        "screen": null,
+        "stand": null,
+        "system": null,
+        "type": "pcdsdevices.happi.containers.LCLSItem",
+        "z": -1.0
+    },
+    "xpp_las_tt_lensh": {
+        "_id": "xpp_las_tt_lensh",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "XPP",
+        "creation": "Tue Jul 17 12:35:03 2018",
+        "device_class": "pcdsdevices.device_types.Newport",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Jul 17 12:35:03 2018",
+        "macros": null,
+        "name": "xpp_las_tt_lensh",
+        "parent": null,
+        "prefix": "XPP:LAS:MMN:13",
+        "screen": null,
+        "stand": null,
+        "system": null,
+        "type": "pcdsdevices.happi.containers.LCLSItem",
+        "z": -1.0
+    },
+    "xpp_las_tt_lensv": {
+        "_id": "xpp_las_tt_lensv",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "XPP",
+        "creation": "Tue Jul 17 12:38:30 2018",
+        "device_class": "pcdsdevices.device_types.Newport",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Jul 17 12:38:30 2018",
+        "macros": null,
+        "name": "xpp_las_tt_lensv",
+        "parent": null,
+        "prefix": "XPP:LAS:MMN:14",
+        "screen": null,
+        "stand": null,
+        "system": null,
+        "type": "pcdsdevices.happi.containers.LCLSItem",
+        "z": -1.0
+    },
+    "xpp_lodcm": {
+        "_id": "xpp_lodcm",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "HXD",
+        "creation": "Tue Feb 27 12:53:14 2018",
+        "device_class": "pcdsdevices.device_types.LODCM",
+        "kwargs": {
+            "main_line": "{{beamline}}",
+            "mono_line": "{{mono_line}}",
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Feb 27 12:53:14 2018",
+        "lightpath": true,
+        "macros": null,
+        "mono_line": "XPP",
+        "name": "xpp_lodcm",
+        "parent": null,
+        "prefix": "XPP:LODCM",
+        "screen": null,
+        "stand": null,
+        "system": "beam control",
+        "type": "pcdsdevices.happi.containers.LODCM",
+        "z": 781.1
+    },
+    "xpp_pulsepicker": {
+        "_id": "xpp_pulsepicker",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "XPP",
+        "creation": "Tue Feb 27 11:31:29 2018",
+        "device_class": "pcdsdevices.device_types.PulsePicker",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Feb 27 11:31:29 2018",
+        "lightpath": true,
+        "macros": null,
+        "name": "xpp_pulsepicker",
+        "parent": null,
+        "prefix": "XPP:SB2:MMS:29",
+        "screen": null,
+        "stand": null,
+        "system": "beam control",
+        "type": "pcdsdevices.happi.containers.PulsePicker",
+        "z": 785.574
+    },
+    "xpp_sb2_high_slits": {
+        "_id": "xpp_sb2_high_slits",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "XPP",
+        "creation": "Tue Feb 27 10:41:25 2018",
+        "device_class": "pcdsdevices.device_types.Slits",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Feb 27 10:41:25 2018",
+        "lightpath": true,
+        "macros": null,
+        "name": "xpp_sb2_high_slits",
+        "parent": null,
+        "prefix": "XPP:SB2H:JAWS",
+        "screen": null,
+        "stand": null,
+        "system": "beam control",
+        "type": "pcdsdevices.happi.containers.Slits",
+        "z": 784.3860000000001
+    },
+    "xpp_sb2_ipm": {
+        "_id": "xpp_sb2_ipm",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "XPP",
+        "creation": "Tue Feb 27 11:40:15 2018",
+        "data": null,
+        "device_class": "pcdsdevices.device_types.IPM",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Feb 27 11:40:15 2018",
+        "lightpath": true,
+        "macros": null,
+        "name": "xpp_sb2_ipm",
+        "parent": null,
+        "prefix": "XPP:SB2:IPM",
+        "screen": null,
+        "stand": null,
+        "system": "diagnostic",
+        "type": "pcdsdevices.happi.containers.IPM",
+        "z": 784.132
+    },
+    "xpp_sb2_low_slits": {
+        "_id": "xpp_sb2_low_slits",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "XPP",
+        "creation": "Tue Feb 27 10:41:25 2018",
+        "device_class": "pcdsdevices.device_types.Slits",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Feb 27 10:41:25 2018",
+        "lightpath": true,
+        "macros": null,
+        "name": "xpp_sb2_low_slits",
+        "parent": null,
+        "prefix": "XPP:SB2L:JAWS",
+        "screen": null,
+        "stand": null,
+        "system": "beam control",
+        "type": "pcdsdevices.happi.containers.Slits",
+        "z": 784.3860000000001
+    },
+    "xpp_sb2_valve": {
+        "_id": "xpp_sb2_valve",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "XPP",
+        "creation": "Thu Feb 15 18:21:13 2018",
+        "device_class": "pcdsdevices.device_types.GateValve",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Feb 15 18:25:24 2018",
+        "lightpath": true,
+        "macros": null,
+        "name": "xpp_sb2_valve",
+        "parent": null,
+        "prefix": "XPP:SB2:VGC:01",
+        "screen": null,
+        "stand": null,
+        "system": "vacuum",
+        "type": "pcdsdevices.happi.containers.GateValve",
+        "z": 784.132
+    },
+    "xpp_sb3_ipm": {
+        "_id": "xpp_sb3_ipm",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "XPP",
+        "creation": "Tue Feb 27 11:40:15 2018",
+        "data": null,
+        "device_class": "pcdsdevices.device_types.IPM",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Feb 27 11:40:15 2018",
+        "lightpath": true,
+        "macros": null,
+        "name": "xpp_sb3_ipm",
+        "parent": null,
+        "prefix": "XPP:SB3:IPM",
+        "screen": null,
+        "stand": null,
+        "system": "diagnostic",
+        "type": "pcdsdevices.happi.containers.IPM",
+        "z": 787.655
+    },
+    "xpp_sb3_pim": {
+        "_id": "xpp_sb3_pim",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "XPP",
+        "creation": "Tue Feb 27 11:15:19 2018",
+        "device_class": "pcdsdevices.pim.PIMWithFocus",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Feb 27 11:15:19 2018",
+        "lightpath": true,
+        "macros": null,
+        "name": "xpp_sb3_pim",
+        "parent": null,
+        "prefix": "XPP:SB3:PIM",
+        "screen": null,
+        "stand": null,
+        "system": null,
+        "type": "pcdsdevices.happi.containers.LCLSItem",
+        "z": 787.8
+    },
+    "xpp_sb3_slits": {
+        "_id": "xpp_sb3_slits",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "XPP",
+        "creation": "Tue Feb 27 10:41:25 2018",
+        "device_class": "pcdsdevices.device_types.Slits",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Feb 27 10:41:25 2018",
+        "lightpath": true,
+        "macros": null,
+        "name": "xpp_sb3_slits",
+        "parent": null,
+        "prefix": "XPP:SB3:JAWS",
+        "screen": null,
+        "stand": null,
+        "system": "beam control",
+        "type": "pcdsdevices.happi.containers.Slits",
+        "z": 787.4860000000001
+    },
+    "xpp_xfls": {
+        "_id": "xpp_xfls",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "XPP",
+        "creation": "Tue Feb 27 14:44:36 2018",
+        "device_class": "pcdsdevices.device_types.XFLS",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Feb 27 14:44:36 2018",
+        "lightpath": true,
+        "macros": null,
+        "name": "xpp_xfls",
+        "parent": null,
+        "prefix": "XPP:SB2:XFLS",
+        "screen": null,
+        "stand": null,
+        "system": null,
+        "type": "pcdsdevices.happi.containers.LCLSItem",
+        "z": 784.9830000000001
+    },
+    "xrt_dg3m_ipm": {
+        "_id": "xrt_dg3m_ipm",
+        "active": false,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "HXD",
+        "creation": "Tue Feb 27 11:40:14 2018",
+        "data": null,
+        "device_class": "pcdsdevices.device_types.IPM",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Wed Apr 18 15:28:14 2018",
+        "macros": null,
+        "name": "xrt_dg3m_ipm",
+        "parent": null,
+        "prefix": "HFX:DG3:IPM",
+        "screen": null,
+        "stand": null,
+        "system": "diagnostic",
+        "type": "pcdsdevices.happi.containers.IPM",
+        "z": 978.9
+    },
+    "xrt_dg3m_pim": {
+        "_id": "xrt_dg3m_pim",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "HXD",
+        "creation": "Tue Feb 27 12:56:05 2018",
+        "data": null,
+        "device_class": "pcdsdevices.pim.PIM",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Feb 27 16:16:11 2018",
+        "macros": null,
+        "name": "xrt_dg3m_pim",
+        "parent": null,
+        "prefix": "HFX:DG3:PIM",
+        "prefix_det": null,
+        "screen": null,
+        "stand": null,
+        "system": "diagnostic",
+        "type": "pcdsdevices.happi.containers.PIM",
+        "z": 978.913
+    },
+    "xrt_dg3m_slits": {
+        "_id": "xrt_dg3m_slits",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "HXD",
+        "creation": "Tue Feb 27 10:41:25 2018",
+        "device_class": "pcdsdevices.device_types.Slits",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Feb 27 10:41:25 2018",
+        "macros": null,
+        "name": "xrt_dg3m_slits",
+        "parent": null,
+        "prefix": "HFX:DG3:JAWS",
+        "screen": null,
+        "stand": null,
+        "system": "beam control",
+        "type": "pcdsdevices.happi.containers.Slits",
+        "z": 978.813
+    },
+    "xrt_dvd_valve": {
+        "_id": "xrt_dvd_valve",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "HXD",
+        "creation": "Thu Feb 15 17:52:07 2018",
+        "device_class": "pcdsdevices.device_types.GateValve",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Feb 15 18:25:23 2018",
+        "lightpath": true,
+        "macros": null,
+        "name": "xrt_dvd_valve",
+        "parent": null,
+        "prefix": "HFX:DVD:VGC:01",
+        "screen": null,
+        "stand": null,
+        "system": "vacuum",
+        "type": "pcdsdevices.happi.containers.GateValve",
+        "z": 945.9630000000001
+    },
+    "xrt_m1h": {
+        "_id": "xrt_m1h",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "HXD",
+        "creation": "Tue Feb 27 16:06:20 2018",
+        "device_class": "pcdsdevices.mirror.PointingMirror",
+        "kwargs": {
+            "in_lines": [
+                "PBT"
+            ],
+            "name": "{{name}}",
+            "out_lines": [
+                "HXD",
+                "MFX",
+                "MEC"
+            ]
+        },
+        "last_edit": "Tue Feb 27 16:06:20 2018",
+        "lightpath": true,
+        "macros": null,
+        "name": "xrt_m1h",
+        "parent": null,
+        "prefix": "XRT:M1H",
+        "prefix_xy": null,
+        "screen": null,
+        "stand": null,
+        "system": "beam control",
+        "type": "pcdsdevices.happi.containers.OffsetMirror",
+        "xgantry_prefix": null,
+        "z": 814.716
+    },
+    "xrt_m2h": {
+        "_id": "xrt_m2h",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "HXD",
+        "creation": "Tue Feb 27 16:11:09 2018",
+        "device_class": "pcdsdevices.mirror.PointingMirror",
+        "kwargs": {
+            "in_lines": [
+                "MEC",
+                "MFX"
+            ],
+            "name": "{{name}}",
+            "out_lines": [
+                "HXD"
+            ]
+        },
+        "last_edit": "Tue Feb 27 16:11:09 2018",
+        "lightpath": true,
+        "macros": null,
+        "name": "xrt_m2h",
+        "parent": null,
+        "prefix": "XRT:M2H",
+        "prefix_xy": null,
+        "screen": null,
+        "stand": null,
+        "system": "beam control",
+        "type": "pcdsdevices.happi.containers.OffsetMirror",
+        "xgantry_prefix": null,
+        "z": 817.1160000000001
+    },
+    "xrt_m3h": {
+        "_id": "xrt_m3h",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "PBT",
+        "creation": "Tue Feb 27 16:12:10 2018",
+        "device_class": "pcdsdevices.device_types.OffsetMirror",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Tue Feb 27 16:12:10 2018",
+        "macros": null,
+        "name": "xrt_m3h",
+        "parent": null,
+        "prefix": "XRT:M3H",
+        "prefix_xy": null,
+        "screen": null,
+        "stand": null,
+        "system": "beam control",
+        "type": "pcdsdevices.happi.containers.OffsetMirror",
+        "xgantry_prefix": null,
+        "z": 927.919
+    },
+    "xrt_mxt_valve": {
+        "_id": "xrt_mxt_valve",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "beamline": "HXD",
+        "creation": "Thu Feb 15 17:52:08 2018",
+        "device_class": "pcdsdevices.device_types.GateValve",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Feb 15 18:25:23 2018",
+        "lightpath": true,
+        "macros": null,
+        "name": "xrt_mxt_valve",
+        "parent": null,
+        "prefix": "HXX:MXT:VGC:03",
+        "screen": null,
+        "stand": null,
+        "system": "vacuum",
+        "type": "pcdsdevices.happi.containers.GateValve",
+        "z": 870.97
     }
 }


### PR DESCRIPTION
Standardizes the device IDs match an entry's name as they were mixed between using prefixes and names in the past.

Code that I ran (minus syntax errors and random prints I wanted to check):
```
In [1]: import json                                                                                     

In [4]: with open('db.json') as infile: 
   ...:     db = json.load(infile) 
   ...:                                                                                                 

In [6]: newdb = {}                                                                                      

In [10]: for key in db: 
    ...:     db[key]['_id'] = db[key]['name'] 
    ...:                                                                                                

In [11]: for key in db: 
    ...:     newdb[db[key]['name']] = db[key] 
    ...:                                                                                                

In [15]: with open('db.json','w') as outfile: 
    ...:     json.dump(newdb, outfile) 
```