### PR TITLE
MNT: move Device items to LCLSItem

### DIFF
--- a/db.json
+++ b/db.json
@@ -14598,7 +14598,7 @@
         "prefix": "SL1K2:EXIT",
         "stand": null,
         "system": null,
-        "type": "Device",
+        "type": "pcdsdevices.happi.containers.LCLSItem",
         "z": 759.122
     },
     "sl1k2_exit_vgc_1": {
@@ -15983,7 +15983,7 @@
         "prefix": "CRIX:VLS:CAM:MMS:PITCH",
         "stand": null,
         "system": null,
-        "type": "Device",
+        "type": "pcdsdevices.happi.containers.LCLSItem",
         "z": 696.0
     },
     "vls_focus_mirror": {
@@ -16012,7 +16012,7 @@
         "prefix": "CRIX:VLS:MMS:MP",
         "stand": null,
         "system": null,
-        "type": "Device",
+        "type": "pcdsdevices.happi.containers.LCLSItem",
         "z": 696.0
     },
     "vls_grating_pitch": {
@@ -16041,7 +16041,7 @@
         "prefix": "CRIX:VLS:MMS:GP",
         "stand": null,
         "system": null,
-        "type": "Device",
+        "type": "pcdsdevices.happi.containers.LCLSItem",
         "z": 696.0
     },
     "vls_slit_down": {
@@ -16070,7 +16070,7 @@
         "prefix": "CRIX:VLS:MMS:SLBOTTOM",
         "stand": null,
         "system": null,
-        "type": "Device",
+        "type": "pcdsdevices.happi.containers.LCLSItem",
         "z": 696.0
     },
     "vls_slit_left": {
@@ -16099,7 +16099,7 @@
         "prefix": "CRIX:VLS:MMS:SLLEFT",
         "stand": null,
         "system": null,
-        "type": "Device",
+        "type": "pcdsdevices.happi.containers.LCLSItem",
         "z": 696.0
     },
     "vls_slit_right": {
@@ -16128,7 +16128,7 @@
         "prefix": "CRIX:VLS:MMS:SLRIGHT",
         "stand": null,
         "system": null,
-        "type": "Device",
+        "type": "pcdsdevices.happi.containers.LCLSItem",
         "z": 696.0
     },
     "vls_slit_up": {
@@ -16157,7 +16157,7 @@
         "prefix": "CRIX:VLS:MMS:SLTOP",
         "stand": null,
         "system": null,
-        "type": "Device",
+        "type": "pcdsdevices.happi.containers.LCLSItem",
         "z": 696.0
     },
     "xcs_attenuator": {


### PR DESCRIPTION
* Simple switch of `Device` to `LCLSItem`
* Did not use happi CLI here as it's a pain to do multiple updates (future feature?)
* Is there anything we might be missing here?
    * Removed `Device` container: https://github.com/pcdshub/happi/commit/5922b25a29b6baf2c61b34cfb502d78baa4da0e5#diff-8109cf7fc7fa79c339020bd5bf7718c1dafab2ebe7e30cad2e3b6be2b62552caL11
    * New `LCLSItem` container: https://github.com/pcdshub/pcdsdevices/blob/06d1fc9d4a71af7b85f6688441995715597a3203/pcdsdevices/happi/containers.py#L11