### PR TITLE
REF: db.json can be relative since happi v1.14.0 (Jul 2022)

### DIFF
--- a/happi.cfg
+++ b/happi.cfg
@@ -1,2 +1,2 @@
 [DEFAULT]
-path = /reg/g/pcds/pyps/apps/hutch-python/device_config/db.json
+path = db.json


### PR DESCRIPTION
`db.json` can be relative to `happi.cfg` since happi v1.14.0 (Jul 2022)
* This PR makes it relative
* This PR makes it easier for non-PCDS machines to use the happi database